### PR TITLE
Add sensors for day 0 now forecast elements

### DIFF
--- a/custom_components/bureau_of_meteorology/PyBoM/collector.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/collector.py
@@ -49,6 +49,9 @@ class Collector:
             flatten_dict(["amount"], d["rain"])
             flatten_dict(["rain", "uv"], d)
 
+            if day == 0:
+                flatten_dict(["now"], d)
+
             # If rain amount max is None, set as rain amount min
             if d["rain_amount_max"] is None:
                 d["rain_amount_max"] = d["rain_amount_min"]

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -169,6 +169,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                      "rain_amount_range": "Rain Amount Range",
                      "rain_chance": "Rain Chance",
                      "fire_danger": "Fire Danger",
+                     "now_now_label": "Now Now Label",
+                     "now_temp_now": "Now Temp Now",
+                     "now_later_label": "Now Later Label",
+                     "now_temp_later": "Now Temp Later",
         }
 
         data_schema = vol.Schema({

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -74,4 +74,8 @@ SENSOR_NAMES = {
     "rain_amount_range": [LENGTH_MILLIMETERS, None],
     "rain_chance": [PERCENTAGE, None],
     "fire_danger": [None, None],
+    "now_now_label":  [None, None],
+    "now_temp_now":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    "now_later_label":  [None, None],
+    "now_temp_later":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
 }


### PR DESCRIPTION
The daily forecast has a json blob in the day 0 forecast called 'now' that contains the next 2 occurrences of min/max max/min and the appropriate labels. It contains 4 useful fields 'now_label', 'temp_now', 'later_label' and 'temp_later'.
Between 6pm to midnight it provides 'now' as the forecast Overnight Min and 'later' as Tomorrows Max.
Between Midnight and 9am it provides 'now' as Min and 'later' as Max
Between 9am and 6pm it provide 'now' as Max and 'later' as Overnight Min
This PR adds the four sensors to the integration.