### PR TITLE
Add sunrise/sunset sensors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This Home Assistant custom component uses the [Bureau of Meteorology (BOM)](http
 [![License][license-shield]](LICENSE.md)
 ![Maintenance](https://img.shields.io/maintenance/yes/2022?style=for-the-badge)
 
+## 1.1.2 - Add Sunrise/Sunset sensors
+- Added sunrise and sunset sensors in the forecast that provide the sunrise/sunset times for the selected forecast period.
+
 ## 1.1.1 - Add Now/Later sensors
 - Added now and later sensors in the forecast that provide the next 2 min/max elements.
 - Fix sensors disappearing when data is not available from the BoM.

--- a/custom_components/bureau_of_meteorology/PyBoM/collector.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/collector.py
@@ -47,7 +47,7 @@ class Collector:
             d["mdi_icon"] = MAP_MDI_ICON[d["icon_descriptor"]]
 
             flatten_dict(["amount"], d["rain"])
-            flatten_dict(["rain", "uv"], d)
+            flatten_dict(["rain", "uv", "astronomical"], d)
 
             if day == 0:
                 flatten_dict(["now"], d)

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -173,6 +173,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                      "now_temp_now": "Now Temp Now",
                      "now_later_label": "Now Later Label",
                      "now_temp_later": "Now Temp Later",
+                     "astronomical_sunrise_time": "Sunrise Time",
+                     "astronomical_sunset_time": "Sunset Time",
         }
 
         data_schema = vol.Schema({

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -78,4 +78,6 @@ SENSOR_NAMES = {
     "now_temp_now":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
     "now_later_label":  [None, None],
     "now_temp_later":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    "astronomical_sunrise_time": [None, DEVICE_CLASS_TIMESTAMP],
+    "astronomical_sunset_time": [None, DEVICE_CLASS_TIMESTAMP],
 }

--- a/custom_components/bureau_of_meteorology/manifest.json
+++ b/custom_components/bureau_of_meteorology/manifest.json
@@ -9,6 +9,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "codeowners": ["@bremor"]
 }


### PR DESCRIPTION
Update version to 1.1.2
- Add sunrise/sunset to forecast data
- Set sensors with missing data to 'unavailable' 