### PR TITLE
Save name when forecast is not checked.

### DIFF
--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -139,7 +139,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self.data[CONF_FORECASTS_CREATE]:
                     return await self.async_step_forecasts_monitored()
                 else:
-                    return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+                   self.data[CONF_FORECASTS_BASENAME] = self.collector.locations_data["data"]["name"]
+                   return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"


### PR DESCRIPTION
If you unchecked the forecast box the weather. sensors failed to be created. This fixes that by adding the name even if the forecast box is unchecked.