### PR TITLE
Add config flow step to set name of weather entity.

### DIFF
--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
 ATTRIBUTION = "Data provided by the Australian Bureau of Meteorology"
 COLLECTOR = "collector"
 
+CONF_WEATHER_NAME = "weather_name"
 CONF_FORECASTS_BASENAME = "forecasts_basename"
 CONF_FORECASTS_CREATE = "forecasts_create"
 CONF_FORECASTS_DAYS = "forecasts_days"

--- a/custom_components/bureau_of_meteorology/strings.json
+++ b/custom_components/bureau_of_meteorology/strings.json
@@ -9,6 +9,13 @@
           "longitude": "[%key:common::config_flow::data::longitude%]"
         }
       },
+      "weather_name": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "weather_name": "[%key:common::config_flow::data::weather_name%]"
+        }
+      },
       "observations": {
         "title": "[%key:common::config_flow::title%]",
         "description": "[%key:common::config_flow::description%]",
@@ -21,7 +28,7 @@
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "observations_basename": "[%key:common::config_flow::data::observations_basename%]",
-          "observations_monitored": "[%key:common::config_flow::data::observations_basename%]"
+          "observations_monitored": "[%key:common::config_flow::data::observations_monitored%]"
         }
       },
       "forecasts": {
@@ -36,7 +43,7 @@
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "forecasts_basename": "[%key:common::config_flow::data::forecasts_basename%]",
-          "forecasts_monitored": "[%key:common::config_flow::data::forecasts_basename%]",
+          "forecasts_monitored": "[%key:common::config_flow::data::forecasts_monitored%]",
           "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]"
         }
       }

--- a/custom_components/bureau_of_meteorology/translations/en.json
+++ b/custom_components/bureau_of_meteorology/translations/en.json
@@ -16,6 +16,13 @@
                     "longitude": "Longitude"
                 }
             },
+            "weather_name": {
+                "title": "Choose Weather Entity Name",
+                "description": "You can choose the name of your BoM weather entity in homeassistant (eg. Warrnambool for \"weather.warrnambool\" or home for \"weather.home\"). The default is taken from your latitude and longitude.",
+                "data": {
+                    "weather_name": "Name of weather entity (weather.name)"
+                }
+            },
             "observations": {
                 "title": "Customise Observation Sensors",
                 "description": "If you do not wish to create any observation sensors, uncheck the box below.",

--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -8,7 +8,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from .const import (
-    ATTRIBUTION, COLLECTOR, CONF_FORECASTS_BASENAME, COORDINATOR, DOMAIN,
+    ATTRIBUTION, COLLECTOR, CONF_WEATHER_NAME, COORDINATOR, DOMAIN,
     MAP_CONDITION,
 )
 
@@ -20,10 +20,12 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     new_devices = []
 
-    if CONF_FORECASTS_BASENAME in config_entry.data:
-        location_name = config_entry.data[CONF_FORECASTS_BASENAME]
-    else:
+    if CONF_WEATHER_NAME in config_entry.data:
+        location_name = config_entry.data[CONF_WEATHER_NAME]
+    elif hasattr(hass_data[COLLECTOR], "location_name"):
         location_name = hass_data[COLLECTOR].location_name
+    else:
+        location_name = "home"
 
     new_devices.append(WeatherDaily(hass_data, location_name))
     new_devices.append(WeatherHourly(hass_data, location_name))
@@ -70,7 +72,7 @@ class WeatherBase(WeatherEntity):
     def icon(self):
         """Return the icon."""
         return self.collector.daily_forecasts_data["data"][0]["mdi_icon"]
-        
+
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""


### PR DESCRIPTION
This PR adds a new step in the config flow to:
- Allow the user to accept or override the name of the weather entity:
  - _independently_ of whether they untick the box for forecast sensors. 
- The forecast location name is used as the default value for `weather_name`. 
- See #95. 

Previously, the `forecast_basename` config variable was used to set the name of the weather entity as well as the basename of additional forecast sensors. If the user asks for no forecast sensors the user would not be given the option to set their preferrred name.