### PR TITLE
Move async_migrate_entry() to __init__.py.

### DIFF
--- a/custom_components/bureau_of_meteorology/__init__.py
+++ b/custom_components/bureau_of_meteorology/__init__.py
@@ -10,7 +10,9 @@ from homeassistant.helpers import debounce
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .PyBoM.collector import Collector
-from .const import DOMAIN, COLLECTOR, COORDINATOR
+from .const import (CONF_WEATHER_NAME,
+                    CONF_FORECASTS_BASENAME,
+                    DOMAIN, COLLECTOR, COORDINATOR)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +24,23 @@ DEBOUNCE_TIME = 60  # in seconds
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the BOM component."""
     hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_migrate_entry(hass, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+
+        new = {**config_entry.data}
+        if CONF_FORECASTS_BASENAME in new:
+            new[CONF_WEATHER_NAME] = config_entry.data[CONF_FORECASTS_BASENAME]
+
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=new)
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True
 
 

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -27,22 +27,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_migrate_entry(hass, config_entry: ConfigEntry):
-        """Migrate old entry."""
-        _LOGGER.debug("Migrating from version %s", config_entry.version)
-
-        if config_entry.version == 1:
-
-            new = {**config_entry.data}
-            if CONF_FORECASTS_BASENAME in new:
-                new[CONF_WEATHER_NAME] = config_entry.data[CONF_FORECASTS_BASENAME]
-
-            config_entry.version = 2
-            hass.config_entries.async_update_entry(config_entry, data=new)
-
-        _LOGGER.info("Migration to version %s successful", config_entry.version)
-        return True
-      
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         data_schema = vol.Schema({

--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     if CONF_WEATHER_NAME in config_entry.data:
         location_name = config_entry.data[CONF_WEATHER_NAME]
     else:
-        location_name = "home"
+        location_name = "Home"
 
     new_devices.append(WeatherDaily(hass_data, location_name))
     new_devices.append(WeatherHourly(hass_data, location_name))


### PR DESCRIPTION
Homeassistant looks for async_migrate_entry() in base module. Tested for upgrade from earlier version and for fresh and config flow.