### PR TITLE
Fix for #113: Failed to setup without Internet.

### DIFF
--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -19,9 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add sensors for passed config_entry in HA."""
     hass_data = hass.data[DOMAIN][config_entry.entry_id]
-    collector = hass_data[COLLECTOR]
 
-    forecast_region = collector.daily_forecasts_data["metadata"]["forecast_region"]
     new_devices = []
 
     if config_entry.data[CONF_OBSERVATIONS_CREATE] == True:


### PR DESCRIPTION
Fix for Issue #113.

Trap error on attempt to connect to BoM services in async_setup_entry() and raise ConfigEntryNotReady so HA will retry the config. HA will keep retrying the config and after network access is available, the config setup completes successfully.

Until the config setup completes, devices will have "unavailable" status.