### PR TITLE
Issue 37: Read warnings data from BoM

### DIFF
--- a/custom_components/bureau_of_meteorology/PyBoM/collector.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/collector.py
@@ -7,7 +7,8 @@ import logging
 from homeassistant.util import Throttle
 
 from .const import (
-    MAP_MDI_ICON, MAP_UV, URL_BASE, URL_DAILY, URL_HOURLY, URL_OBSERVATIONS,
+    MAP_MDI_ICON, MAP_UV, URL_BASE, URL_DAILY,
+    URL_HOURLY, URL_OBSERVATIONS, URL_WARNINGS
 )
 from .helpers import (
     flatten_dict, geohash_encode,
@@ -24,6 +25,7 @@ class Collector:
         self.observations_data = None
         self.daily_forecasts_data = None
         self.hourly_forecasts_data = None
+        self.warnings_data = None
         self.geohash = geohash_encode(latitude, longitude)
         _LOGGER.debug(f"Geohash: {self.geohash}")
 
@@ -82,7 +84,7 @@ class Collector:
     async def async_update(self):
         """Refresh the data on the collector object."""
         async with aiohttp.ClientSession() as session:
-        
+
             if self.locations_data is None:
                 async with session.get(URL_BASE + self.geohash) as resp:
                     self.locations_data = await resp.json()
@@ -112,3 +114,7 @@ class Collector:
                 self.hourly_forecasts_data = await resp.json()
                 await self.format_hourly_forecast_data()
                 _LOGGER.debug(f"Hourly Forecasts data: {self.hourly_forecasts_data}")
+
+            async with session.get(URL_BASE + self.geohash + URL_WARNINGS) as resp:
+                self.warnings_data = await resp.json()
+                _LOGGER.debug(f"Warnings data: {self.warnings_data}")

--- a/custom_components/bureau_of_meteorology/PyBoM/const.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/const.py
@@ -42,4 +42,5 @@ URL_BASE = "https://api.weather.bom.gov.au/v1/locations/"
 URL_DAILY = "/forecasts/daily"
 URL_HOURLY = "/forecasts/hourly"
 URL_OBSERVATIONS = "/observations"
+URL_WARNINGS = "/warnings"
 

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -16,6 +16,7 @@ from .const import (CONF_WEATHER_NAME,
                     CONF_OBSERVATIONS_CREATE,
                     CONF_OBSERVATIONS_MONITORED,
                     CONF_WARNINGS_CREATE,
+                    CONF_WARNINGS_BASENAME,
                     DOMAIN,
 )
 from .PyBoM.collector import Collector
@@ -74,7 +75,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Save the user input into self.data so it's retained
                 self.data.update(user_input)
 
-                return await self.async_step_observations()
+                return await self.async_step_sensors_create()
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -87,10 +88,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="weather_name", data_schema=data_schema, errors=errors
         )
 
-    async def async_step_observations(self, user_input=None):
+    async def async_step_sensors_create(self, user_input=None):
         """Handle the observations step."""
         data_schema = vol.Schema({
             vol.Required(CONF_OBSERVATIONS_CREATE, default=True): bool,
+            vol.Required(CONF_FORECASTS_CREATE, default=True): bool,
+            vol.Required(CONF_WARNINGS_CREATE, default=True): bool,
         })
 
         errors = {}
@@ -102,8 +105,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Move onto the next step of the config flow
                 if self.data[CONF_OBSERVATIONS_CREATE]:
                     return await self.async_step_observations_monitored()
+                elif self.data[CONF_FORECASTS_CREATE]:
+                    return await self.async_step_forecasts_monitored()
+                elif self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
                 else:
-                    return await self.async_step_forecasts()
+                    return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -113,7 +120,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
-            step_id="observations", data_schema=data_schema, errors=errors
+            step_id="sensors_create", data_schema=data_schema, errors=errors
         )
 
     async def async_step_observations_monitored(self, user_input=None):
@@ -138,7 +145,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 self.data.update(user_input)
-                return await self.async_step_forecasts()
+
+                # Move onto the next step of the config flow
+                if self.data[CONF_FORECASTS_CREATE]:
+                    return await self.async_step_forecasts_monitored()
+                elif self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
+                else:
+                    return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -148,36 +163,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
             step_id="observations_monitored", data_schema=data_schema, errors=errors
-        )
-
-    async def async_step_forecasts(self, user_input=None):
-        """Handle the forecasts step."""
-        data_schema = vol.Schema({
-            vol.Required(CONF_FORECASTS_CREATE, default=True): bool,
-        })
-
-        errors = {}
-        if user_input is not None:
-            try:
-                # Save the user input into self.data so it's retained
-                self.data.update(user_input)
-
-                # Move onto the next step of the config flow
-                if self.data[CONF_FORECASTS_CREATE]:
-                    return await self.async_step_forecasts_monitored()
-                else:
-                   self.data[CONF_FORECASTS_BASENAME] = self.collector.locations_data["data"]["name"]
-                   return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
-
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-
-        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
-        return self.async_show_form(
-            step_id="forecasts", data_schema=data_schema, errors=errors
         )
 
     async def async_step_forecasts_monitored(self, user_input=None):
@@ -209,7 +194,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_FORECASTS_BASENAME, default=self.collector.locations_data["data"]["name"]): str,
             vol.Required(CONF_FORECASTS_MONITORED): cv.multi_select(monitored),
             vol.Required(CONF_FORECASTS_DAYS): vol.All(vol.Coerce(int), vol.Range(0, 7)),
-            vol.Required(CONF_WARNINGS_CREATE, default=True): bool,
+        })
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+
+                if self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
+                return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+    async def async_step_warnings_basename(self, user_input=None):
+        """Handle the forecasts monitored step."""
+        data_schema = vol.Schema({
+            vol.Required(CONF_WARNINGS_BASENAME, default=self.collector.locations_data["data"]["name"]): str,
         })
 
         errors = {}
@@ -225,7 +230,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
-            step_id="forecasts_monitored", data_schema=data_schema, errors=errors
+            step_id="warnings_basename", data_schema=data_schema, errors=errors
         )
 
 

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -15,6 +15,7 @@ from .const import (CONF_WEATHER_NAME,
                     CONF_OBSERVATIONS_BASENAME,
                     CONF_OBSERVATIONS_CREATE,
                     CONF_OBSERVATIONS_MONITORED,
+                    CONF_WARNINGS_CREATE,
                     DOMAIN,
 )
 from .PyBoM.collector import Collector
@@ -208,6 +209,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_FORECASTS_BASENAME, default=self.collector.locations_data["data"]["name"]): str,
             vol.Required(CONF_FORECASTS_MONITORED): cv.multi_select(monitored),
             vol.Required(CONF_FORECASTS_DAYS): vol.All(vol.Coerce(int), vol.Range(0, 7)),
+            vol.Required(CONF_WARNINGS_CREATE, default=True): bool,
         })
 
         errors = {}

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -17,6 +17,7 @@ CONF_OBSERVATIONS_BASENAME = "observations_basename"
 CONF_OBSERVATIONS_CREATE = "observations_create"
 CONF_OBSERVATIONS_MONITORED = "observations_monitored"
 CONF_WARNINGS_CREATE = "warnings_create"
+CONF_WARNINGS_BASENAME = "warnings_basename"
 
 COORDINATOR = "coordinator"
 DOMAIN = "bureau_of_meteorology"

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -16,6 +16,7 @@ CONF_FORECASTS_MONITORED = "forecasts_monitored"
 CONF_OBSERVATIONS_BASENAME = "observations_basename"
 CONF_OBSERVATIONS_CREATE = "observations_create"
 CONF_OBSERVATIONS_MONITORED = "observations_monitored"
+CONF_WARNINGS_CREATE = "warnings_create"
 
 COORDINATOR = "coordinator"
 DOMAIN = "bureau_of_meteorology"
@@ -81,4 +82,5 @@ SENSOR_NAMES = {
     "now_temp_later":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
     "astronomical_sunrise_time": [None, DEVICE_CLASS_TIMESTAMP],
     "astronomical_sunset_time": [None, DEVICE_CLASS_TIMESTAMP],
+    "warnings": [None, None],
 }

--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -10,7 +10,8 @@ from homeassistant.helpers.entity import Entity
 from .const import (
     ATTRIBUTION, COLLECTOR, CONF_FORECASTS_BASENAME, CONF_FORECASTS_CREATE,
     CONF_FORECASTS_DAYS, CONF_FORECASTS_MONITORED, CONF_OBSERVATIONS_BASENAME,
-    CONF_OBSERVATIONS_CREATE, CONF_OBSERVATIONS_MONITORED, CONF_WARNINGS_CREATE,
+    CONF_OBSERVATIONS_CREATE, CONF_OBSERVATIONS_MONITORED,
+    CONF_WARNINGS_CREATE, CONF_WARNINGS_BASENAME,
     COORDINATOR, DOMAIN, SENSOR_NAMES,
 )
 
@@ -39,7 +40,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
                     new_devices.append(ForecastSensor(hass_data, config_entry.data[CONF_FORECASTS_BASENAME], day, forecast))
 
     if config_entry.data.get(CONF_WARNINGS_CREATE, True) == True:
-        new_devices.append(WarningsSensor(hass_data, config_entry.data[CONF_FORECASTS_BASENAME], "warnings"))
+        basename = config_entry.data.get(CONF_WARNINGS_BASENAME, None)
+        if basename is None:
+            basename = config_entry.data.get(CONF_FORECASTS_BASENAME, None)
+        if basename:
+            new_devices.append(WarningsSensor(hass_data, basename, "warnings"))
 
     if new_devices:
         async_add_devices(new_devices)

--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -197,7 +197,7 @@ class WarningsSensor(SensorBase):
     def state(self):
         """Return the state of the sensor."""
         # If there is no data for this day, return state as 'None'.
-        return len(self.collector.warnings_data["data"]) > 0
+        return len(self.collector.warnings_data["data"])
 
     @property
     def name(self):

--- a/custom_components/bureau_of_meteorology/strings.json
+++ b/custom_components/bureau_of_meteorology/strings.json
@@ -44,7 +44,8 @@
         "data": {
           "forecasts_basename": "[%key:common::config_flow::data::forecasts_basename%]",
           "forecasts_monitored": "[%key:common::config_flow::data::forecasts_monitored%]",
-          "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]"
+          "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]",
+          "warnings_create": "[%key:common::config_flow::data::warnings_create%]"
         }
       }
     },

--- a/custom_components/bureau_of_meteorology/strings.json
+++ b/custom_components/bureau_of_meteorology/strings.json
@@ -16,11 +16,13 @@
           "weather_name": "[%key:common::config_flow::data::weather_name%]"
         }
       },
-      "observations": {
+      "sensors_create": {
         "title": "[%key:common::config_flow::title%]",
         "description": "[%key:common::config_flow::description%]",
         "data": {
-          "observations_create": "[%key:common::config_flow::data::observations_create%]"
+          "observations_create": "[%key:common::config_flow::data::observations_create%]",
+          "forecasts_create": "[%key:common::config_flow::data::forecasts_create%]",
+          "warnings_create": "[%key:common::config_flow::data::warnings_create%]"
         }
       },
       "observations_monitored": {
@@ -31,25 +33,25 @@
           "observations_monitored": "[%key:common::config_flow::data::observations_monitored%]"
         }
       },
-      "forecasts": {
-        "title": "[%key:common::config_flow::title%]",
-        "description": "[%key:common::config_flow::description%]",
-        "data": {
-          "forecasts_create": "[%key:common::config_flow::data::forecasts_create%]"
-        }
-      },
       "forecasts_monitored": {
         "title": "[%key:common::config_flow::title%]",
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "forecasts_basename": "[%key:common::config_flow::data::forecasts_basename%]",
           "forecasts_monitored": "[%key:common::config_flow::data::forecasts_monitored%]",
-          "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]",
-          "warnings_create": "[%key:common::config_flow::data::warnings_create%]"
+          "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]"
         }
       }
     },
-    "error": {
+    "warnings_basename": {
+      "title": "[%key:common::config_flow::title%]",
+      "description": "[%key:common::config_flow::description%]",
+      "data": {
+        "warnings_basename": "[%key:common::config_flow::data::warnings_basename%]"
+      }
+    }
+  },
+  "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },

--- a/custom_components/bureau_of_meteorology/translations/en.json
+++ b/custom_components/bureau_of_meteorology/translations/en.json
@@ -47,11 +47,12 @@
             },
             "forecasts_monitored": {
                 "title": "Customise Forecast Sensors",
-                "description": "You can customise the basename of your forecast sensors, which forecast sensors you would like to create, and how many days you would like the forecast to be (day 5 is always available, day 6 and 7 are only sometimes available).",
+                "description": "You can customise the basename of your forecast sensors, whether you would like to create a sensor for the weather warnings data, which forecast sensors you would like to create, and how many days you would like the forecast to be (day 5 is always available, day 6 and 7 are only sometimes available).",
                 "data": {
                     "forecasts_basename": "Choose a 'basename' for your forecast sensors (e.g. sensor.basename_temp_max_0)",
                     "forecasts_monitored": "Which sensors would you like to create?",
-                    "forecasts_days": "How many forecast days would you like? (0-7)"
+                    "forecasts_days": "How many forecast days would you like? (0-7)",
+                    "warnings_create": "Create a sensor to hold warnings data?"
                 }
             }
         }

--- a/custom_components/bureau_of_meteorology/translations/en.json
+++ b/custom_components/bureau_of_meteorology/translations/en.json
@@ -9,8 +9,8 @@
         },
         "step": {
             "user": {
-                "title": "Set up Bureau of Meteorology",
-                "description": "Latitude and longitude will be used to find the nearest weather station and to generate a forecast for your location.",
+                "title": "Set up Australian Bureau of Meteorology",
+                "description": "Latitude and longitude will be used to find the nearest weather station and to generate a forecast for your location. The default values come from your homeassistant \"Home\" zone (See Settings/Areas & Zones/Zones).",
                 "data": {
                     "latitude": "Latitude",
                     "longitude": "Longitude"
@@ -18,41 +18,42 @@
             },
             "weather_name": {
                 "title": "Choose Weather Entity Name",
-                "description": "You can choose the name of your BoM weather entity in homeassistant (eg. Warrnambool for \"weather.warrnambool\" or home for \"weather.home\"). The default is taken from your latitude and longitude.",
+                "description": "The weather entity in homeassistant holds all the basic weather observation and forecast information needed for most weather display cards. You can choose the name of your BoM weather entity (eg. Warrnambool for \"weather.warrnambool\" or home for \"weather.home\").",
                 "data": {
                     "weather_name": "Name of weather entity (weather.name)"
                 }
             },
-            "observations": {
-                "title": "Customise Observation Sensors",
-                "description": "If you do not wish to create any observation sensors, uncheck the box below.",
+            "sensors_create": {
+                "title": "Customise Additional Sensors",
+                "description": "You can also create additional sensors for specific BoM observations, forecasts and warnings (eg. sensor.brisbane_humidity). If you wish to create any additional sensors, check the boxes below and you will be asked which sensors to create.",
                 "data": {
-                    "observations_create": "Create observation sensors"
+                    "observations_create": "Create observation sensors?",
+                    "forecasts_create": "Create forecast sensors?",
+                    "warnings_create": "Create a sensor to hold warnings data?"
                 }
             },
             "observations_monitored": {
                 "title": "Customise Observation Sensors",
-                "description": "You can customise the basename of your observation sensors and which observation sensors you would like to create.",
+                "description": "You can customise the basename of your observation sensors and which observation sensors you would like to create. The default is the name of your nearest BoM weather station.",
                 "data": {
-                    "observations_basename": "Basename for all of your observation sensors",
-                    "observations_monitored": "Which sensors would you like to create?"
-                }
-            },
-            "forecasts": {
-                "title": "Customise Forecast Sensors",
-                "description": "If you do not wish to create any forecast sensors, uncheck the box below.",
-                "data": {
-                    "forecasts_create": "Create forecast sensors"
+                    "observations_basename": "Basename for the new observation sensors (e.g. sensor.basename_temperature)",
+                    "observations_monitored": "Choose the additional observation sensors you would like?"
                 }
             },
             "forecasts_monitored": {
                 "title": "Customise Forecast Sensors",
-                "description": "You can customise the basename of your forecast sensors, whether you would like to create a sensor for the weather warnings data, which forecast sensors you would like to create, and how many days you would like the forecast to be (day 5 is always available, day 6 and 7 are only sometimes available).",
+                "description": "You can customise the basename of your forecast sensors, which forecast sensors you would like to create, and how many days of forecast sensors to create (day 5 is always available, day 6 and 7 are only sometimes available). Note: this can generate a lot of new sensors!",
                 "data": {
                     "forecasts_basename": "Choose a 'basename' for your forecast sensors (e.g. sensor.basename_temp_max_0)",
                     "forecasts_monitored": "Which sensors would you like to create?",
-                    "forecasts_days": "How many forecast days would you like? (0-7)",
-                    "warnings_create": "Create a sensor to hold warnings data?"
+                    "forecasts_days": "How many days of forecast sensors would you like? (0-7)"
+                }
+            },
+            "warnings_basename": {
+                "title": "Customise Warnings Sensor",
+                "description": "You can set the basename of the sensor which will hold the warnings data (e.g. Cairns for sensor.cairns_warnings).",
+                "data": {
+                    "warnings_basename": "Choose a name for your warnings sensor"
                 }
             }
         }


### PR DESCRIPTION
This PR addresses requests to support BoM warnings (see Issue #37).

Data is collected from the BoM warnings API.

This data may be made available through an additional `warnings` sensor which can be used in scripts and automations. New or updated lovelace cards would be required to display this data.

The state of the sensor is the number of warnings and the warnings data is stored as a list in the "warnings" attribute of the sensor.

```
sensor.melbourne_forecast_warnings:
- state: 1
- Attributes:
      response_timestamp: 2022-05-16T13:03:47Z
      copyright: This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). 
          You must not use, copy or share this API without express permission from the Bureau. Please contact us for more 
          information. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details.
      attribution: Data provided by the Australian Bureau of Meteorology
      warnings: 
      - id: VIC_MW005_IDV20600
        type: marine_wind_warning
        title: Marine Wind Warning for Victoria
        short_title: Marine Wind Warning
        state: VIC
        warning_group_type: minor
        issue_time: '2022-05-16T12:00:00Z'
        expiry_time: '2022-05-16T19:00:00Z'
        phase: cancelled
      friendly_name: Melbourne Forecast Warnings
```