### PR TITLE
Embed tzinfo in timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Home Assistant custom component uses the [Bureau of Meteorology (BOM)](http
 
 ## 1.1.12 - Embed timezone in timestamps
   - This embeds the timezone of the location in timestamps, whcih is needed to display timess correctly if you create sensors in a different timezone to where the HA server is located.
+
 ## 1.1.11 - Fixes for 2022.7.0
   - This is to address an architecture change in 2022.7.0 and will not install on earlier versions of HA.
   

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This Home Assistant custom component uses the [Bureau of Meteorology (BOM)](http
 ![Maintenance](https://img.shields.io/maintenance/yes/2022?style=for-the-badge)
 
 
+## 1.1.12 - Embed timezone in timestamps
+  - This embeds the timezone of the location in timestamps, whcih is needed to display timess correctly if you create sensors in a different timezone to where the HA server is located.
 ## 1.1.11 - Fixes for 2022.7.0
   - This is to address an architecture change in 2022.7.0 and will not install on earlier versions of HA.
   

--- a/custom_components/bureau_of_meteorology/manifest.json
+++ b/custom_components/bureau_of_meteorology/manifest.json
@@ -9,6 +9,6 @@
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
-  "version": "1.1.11",
+  "version": "1.1.12",
   "codeowners": ["@bremor"]
 }

--- a/custom_components/bureau_of_meteorology/manifest.json
+++ b/custom_components/bureau_of_meteorology/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/bremor/bureau_of_meteorology",
   "issue_tracker": "https://github.com/bremor/bureau_of_meteorology/issues",
-  "requirements": [],
+  "requirements": ["iso8601"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -1,5 +1,9 @@
 """Platform for sensor integration."""
 import logging
+from datetime import datetime, tzinfo
+from pytz import timezone
+import pytz
+import iso8601
 
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.const import (
@@ -131,9 +135,10 @@ class WeatherDaily(WeatherBase):
         """Return the forecast."""
         forecasts = []
         days = len(self.collector.daily_forecasts_data["data"])
+        tzinfo = pytz.timezone(self.collector.locations_data["data"]["timezone"])
         for day in range(0, days):
             forecast = {
-                "datetime": self.collector.daily_forecasts_data["data"][day]["date"],
+                "datetime": iso8601.parse_date(self.collector.daily_forecasts_data["data"][day]["date"]).astimezone(tzinfo).isoformat(),
                 "native_temperature": self.collector.daily_forecasts_data["data"][day]["temp_max"],
                 "condition": MAP_CONDITION[self.collector.daily_forecasts_data["data"][day]["icon_descriptor"]],
                 "templow": self.collector.daily_forecasts_data["data"][day]["temp_min"],
@@ -166,9 +171,10 @@ class WeatherHourly(WeatherBase):
         """Return the forecast."""
         forecasts = []
         hours = len(self.collector.hourly_forecasts_data["data"])
+        tzinfo = pytz.timezone(self.collector.locations_data["data"]["timezone"])
         for hour in range(0, hours):
             forecast = {
-                "datetime": self.collector.hourly_forecasts_data["data"][hour]["time"],
+                "datetime": iso8601.parse_date(self.collector.hourly_forecasts_data["data"][hour]["time"]).astimezone(tzinfo).isoformat(),
                 "native_temperature": self.collector.hourly_forecasts_data["data"][hour]["temp"],
                 "condition": MAP_CONDITION[self.collector.hourly_forecasts_data["data"][hour]["icon_descriptor"]],
                 "native_precipitation": self.collector.hourly_forecasts_data["data"][hour]["rain_amount_max"],


### PR DESCRIPTION
This changes timestamps from UTC time to local time with an offset. This is needed to display times correctly if the sensor is in a different timezone to the HA server.