### PR TITLE
Add integration configuration and device registry entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+config/
+.python_version

--- a/custom_components/bureau_of_meteorology/__init__.py
+++ b/custom_components/bureau_of_meteorology/__init__.py
@@ -3,19 +3,33 @@ import asyncio
 import datetime
 import logging
 
+from aiohttp.client_exceptions import ClientConnectorError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import debounce
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import debounce
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from aiohttp.client_exceptions import ClientConnectorError
-
+from .const import (
+    COLLECTOR,
+    CONF_FORECASTS_BASENAME,
+    CONF_FORECASTS_CREATE,
+    CONF_FORECASTS_DAYS,
+    CONF_FORECASTS_MONITORED,
+    CONF_OBSERVATIONS_BASENAME,
+    CONF_OBSERVATIONS_CREATE,
+    CONF_OBSERVATIONS_MONITORED,
+    CONF_WARNINGS_BASENAME,
+    CONF_WARNINGS_CREATE,
+    CONF_WEATHER_NAME,
+    COORDINATOR,
+    DOMAIN,
+    UPDATE_LISTENER,
+)
 from .PyBoM.collector import Collector
-from .const import (CONF_WEATHER_NAME,
-                    CONF_FORECASTS_BASENAME,
-                    DOMAIN, COLLECTOR, COORDINATOR)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,13 +38,14 @@ PLATFORMS = ["sensor", "weather"]
 DEFAULT_SCAN_INTERVAL = datetime.timedelta(minutes=10)
 DEBOUNCE_TIME = 60  # in seconds
 
+
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the BOM component."""
     hass.data.setdefault(DOMAIN, {})
     return True
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry):
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
@@ -49,27 +64,14 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up BOM from a config entry."""
-    collector = Collector(
-        entry.data[CONF_LATITUDE],
-        entry.data[CONF_LONGITUDE]
-    )
+    collector = Collector(entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE])
 
     try:
         await collector.async_update()
     except ClientConnectorError as ex:
         raise ConfigEntryNotReady from ex
 
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"BOM observation {entry.data[CONF_WEATHER_NAME]}",
-        update_method=collector.async_update,
-        update_interval=DEFAULT_SCAN_INTERVAL,
-        request_refresh_debouncer=debounce.Debouncer(
-            hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
-        )
-    )
-
+    coordinator = BomDataUpdateCoordinator(hass=hass, collector=collector)
     await coordinator.async_refresh()
 
     hass_data = hass.data.setdefault(DOMAIN, {})
@@ -83,21 +85,125 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
+    update_listener = entry.add_update_listener(async_update_options)
+    hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener
+
     return True
 
 
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle config entry updates."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
+    """Remove unconfigured entities and unload the config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    entities_to_keep = []
+
+    # if observations are enabled, keep the configured observation sensors
+    if entry.options.get(CONF_OBSERVATIONS_CREATE) is True:
+        for observation in entry.options.get(CONF_OBSERVATIONS_MONITORED):
+            entities_to_keep.append(
+                f"sensor.{str(entry.options.get(CONF_OBSERVATIONS_BASENAME)).lower()}_{str(observation).lower()}"
+            )
+
+    # if forecasts are enabled, keep the configured forecast sensors
+    if entry.options.get(CONF_FORECASTS_CREATE) is True:
+        for day in range(0, entry.options.get(CONF_FORECASTS_DAYS, 0) + 1):
+            for forecast in entry.options.get(CONF_FORECASTS_MONITORED):
+                if forecast in [
+                    "now_now_label",
+                    "now_temp_now",
+                    "now_later_label",
+                    "now_temp_later",
+                ]:
+                    if day == 0:
+                        entities_to_keep.append(
+                            f"sensor.{str(entry.options.get(CONF_FORECASTS_BASENAME)).lower()}_{str(forecast).lower()}"
+                        )
+                    else:
+                        entities_to_keep.append(
+                            f"sensor.{str(entry.options.get(CONF_FORECASTS_BASENAME)).lower()}_{str(day)}_{str(forecast).lower()}"
+                        )
+
+    # if warnings are enabled, keep the warnings sensor
+    if entry.options.get(CONF_WARNINGS_CREATE) is True:
+        basename = entry.options.get(CONF_WARNINGS_BASENAME)
+        if basename is None:
+            basename = entry.options.get(CONF_FORECASTS_BASENAME)
+            if basename:
+                entities_to_keep.append(f"sensor.{str(basename).lower()}_warnings")
+
+    # if the weather entity basename has not changed, keep the weather entities
+    weather_name = entry.options.get(
+        CONF_WEATHER_NAME, entry.data.get(CONF_WEATHER_NAME, "Home")
     )
+    entities_to_keep.append(f"weather.{str(weather_name).lower()}")
+    entities_to_keep.append(f"weather.{str(weather_name).lower()}_hourly")
+
+    _LOGGER.debug("Keeping %s", entities_to_keep)
+
+    # remove any sensors that are not configured
+    for entity in entities:
+        if entity.entity_id not in entities_to_keep:
+            entity_registry.async_remove(entity_id=entity.entity_id)
+            _LOGGER.debug("Removing %s from entity registry", entity.entity_id)
 
     if unload_ok:
+        update_listener = hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER]
+        update_listener()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+class BomDataUpdateCoordinator(DataUpdateCoordinator):
+    """Data update coordinator for Bureau of Meteorology."""
+
+    def __init__(self, hass: HomeAssistant, collector: Collector) -> None:
+        """Initialise the data update coordinator."""
+        self.collector = collector
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            name=DOMAIN,
+            update_method=self.collector.async_update,
+            update_interval=DEFAULT_SCAN_INTERVAL,
+            request_refresh_debouncer=debounce.Debouncer(
+                hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
+            ),
+        )
+
+        self.entity_registry_updated_unsub = self.hass.bus.async_listen(
+            er.EVENT_ENTITY_REGISTRY_UPDATED, self.entity_registry_updated
+        )
+
+    @callback
+    def entity_registry_updated(self, event):
+        """Handle entity registry update events."""
+        if event.data["action"] == "remove":
+            self.remove_empty_devices()
+
+    def remove_empty_devices(self):
+        """Remove devices with no entities."""
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        device_list = dr.async_entries_for_config_entry(
+            device_registry, self.config_entry.entry_id
+        )
+
+        for device_entry in device_list:
+            entities = er.async_entries_for_device(
+                entity_registry, device_entry.id, include_disabled_entities=True
+            )
+
+            if not entities:
+                _LOGGER.debug("Removing orphaned device: %s", device_entry.name)
+                device_registry.async_update_device(
+                    device_entry.id, remove_config_entry_id=self.config_entry.entry_id
+                )

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -1,23 +1,24 @@
 """Config flow for BOM."""
 import logging
 
-import voluptuous as vol
-
-from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant import config_entries, exceptions
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant, callback
 
-from .const import (CONF_WEATHER_NAME,
-                    CONF_FORECASTS_BASENAME,
-                    CONF_FORECASTS_CREATE,
-                    CONF_FORECASTS_DAYS,
-                    CONF_FORECASTS_MONITORED,
-                    CONF_OBSERVATIONS_BASENAME,
-                    CONF_OBSERVATIONS_CREATE,
-                    CONF_OBSERVATIONS_MONITORED,
-                    CONF_WARNINGS_CREATE,
-                    CONF_WARNINGS_BASENAME,
-                    DOMAIN,
+from .const import (
+    CONF_FORECASTS_BASENAME,
+    CONF_FORECASTS_CREATE,
+    CONF_FORECASTS_DAYS,
+    CONF_FORECASTS_MONITORED,
+    CONF_OBSERVATIONS_BASENAME,
+    CONF_OBSERVATIONS_CREATE,
+    CONF_OBSERVATIONS_MONITORED,
+    CONF_WARNINGS_BASENAME,
+    CONF_WARNINGS_CREATE,
+    CONF_WEATHER_NAME,
+    DOMAIN,
 )
 from .PyBoM.collector import Collector
 
@@ -26,15 +27,25 @@ _LOGGER = logging.getLogger(__name__)
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BOM."""
+
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        return BomOptionsFlow(config_entry)
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        data_schema = vol.Schema({
-            vol.Required(CONF_LATITUDE, default=self.hass.config.latitude): float,
-            vol.Required(CONF_LONGITUDE, default=self.hass.config.longitude): float,
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_LATITUDE, default=self.hass.config.latitude): float,
+                vol.Required(CONF_LONGITUDE, default=self.hass.config.longitude): float,
+            }
+        )
 
         errors = {}
         if user_input is not None:
@@ -71,9 +82,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_weather_name(self, user_input=None):
         """Handle the locations step."""
-        data_schema = vol.Schema({
-            vol.Required(CONF_WEATHER_NAME, default=self.collector.locations_data["data"]["name"]): str,
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_WEATHER_NAME,
+                    default=self.collector.locations_data["data"]["name"],
+                ): str,
+            }
+        )
 
         errors = {}
         if user_input is not None:
@@ -96,11 +112,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_sensors_create(self, user_input=None):
         """Handle the observations step."""
-        data_schema = vol.Schema({
-            vol.Required(CONF_OBSERVATIONS_CREATE, default=True): bool,
-            vol.Required(CONF_FORECASTS_CREATE, default=True): bool,
-            vol.Required(CONF_WARNINGS_CREATE, default=True): bool,
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_OBSERVATIONS_CREATE, default=True): bool,
+                vol.Required(CONF_FORECASTS_CREATE, default=True): bool,
+                vol.Required(CONF_WARNINGS_CREATE, default=True): bool,
+            }
+        )
 
         errors = {}
         if user_input is not None:
@@ -116,7 +134,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 elif self.data[CONF_WARNINGS_CREATE]:
                     return await self.async_step_warnings_basename()
                 else:
-                    return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+                    return self.async_create_entry(
+                        title=self.collector.locations_data["data"]["name"],
+                        data=self.data,
+                    )
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -131,21 +152,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_observations_monitored(self, user_input=None):
         """Handle the observations monitored step."""
-        monitored = {"temp": "Temperature",
-                     "temp_feels_like": "Temperature Feels Like",
-                     "rain_since_9am": "Rain Since 9am",
-                     "humidity": "Humidity",
-                     "wind_speed_kilometre": "Wind Speed Kilometre",
-                     "wind_speed_knot": "Wind Speed Knot",
-                     "wind_direction": "Wind Direction",
-                     "gust_speed_kilometre": "Gust Speed Kilometre",
-                     "gust_speed_knot": "Gust Speed Knot",
+        monitored = {
+            "temp": "Temperature",
+            "temp_feels_like": "Temperature Feels Like",
+            "rain_since_9am": "Rain Since 9am",
+            "humidity": "Humidity",
+            "wind_speed_kilometre": "Wind Speed Kilometre",
+            "wind_speed_knot": "Wind Speed Knot",
+            "wind_direction": "Wind Direction",
+            "gust_speed_kilometre": "Gust Speed Kilometre",
+            "gust_speed_knot": "Gust Speed Knot",
         }
 
-        data_schema = vol.Schema({
-            vol.Required(CONF_OBSERVATIONS_BASENAME, default=self.collector.observations_data["data"]["station"]["name"]): str,
-            vol.Required(CONF_OBSERVATIONS_MONITORED): cv.multi_select(monitored),
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_OBSERVATIONS_BASENAME,
+                    default=self.collector.observations_data["data"]["station"]["name"],
+                ): str,
+                vol.Required(CONF_OBSERVATIONS_MONITORED): cv.multi_select(monitored),
+            }
+        )
 
         errors = {}
         if user_input is not None:
@@ -158,7 +185,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 elif self.data[CONF_WARNINGS_CREATE]:
                     return await self.async_step_warnings_basename()
                 else:
-                    return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+                    return self.async_create_entry(
+                        title=self.collector.locations_data["data"]["name"],
+                        data=self.data,
+                    )
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -173,35 +203,43 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_forecasts_monitored(self, user_input=None):
         """Handle the forecasts monitored step."""
-        monitored = {"temp_max": "Max. Temperature",
-                     "temp_min": "Min. Temperature",
-                     "extended_text": "Extended Text",
-                     "icon_descriptor": "Icon Descriptor",
-                     "mdi_icon": "MDI Icon",
-                     "short_text": "Short Text",
-                     "uv_category": "UV Category",
-                     "uv_max_index": "UV Max Index",
-                     "uv_start_time": "UV Protection Start Time",
-                     "uv_end_time": "UV Protection End Time",
-                    "uv_forecast": "UV Forecast Summary",
-                     "rain_amount_min": "Rain Amount Min.",
-                     "rain_amount_max": "Rain Amount Max.",
-                     "rain_amount_range": "Rain Amount Range",
-                     "rain_chance": "Rain Chance",
-                     "fire_danger": "Fire Danger",
-                     "now_now_label": "Now Now Label",
-                     "now_temp_now": "Now Temp Now",
-                     "now_later_label": "Now Later Label",
-                     "now_temp_later": "Now Temp Later",
-                     "astronomical_sunrise_time": "Sunrise Time",
-                     "astronomical_sunset_time": "Sunset Time",
+        monitored = {
+            "temp_max": "Max. Temperature",
+            "temp_min": "Min. Temperature",
+            "extended_text": "Extended Text",
+            "icon_descriptor": "Icon Descriptor",
+            "mdi_icon": "MDI Icon",
+            "short_text": "Short Text",
+            "uv_category": "UV Category",
+            "uv_max_index": "UV Max Index",
+            "uv_start_time": "UV Protection Start Time",
+            "uv_end_time": "UV Protection End Time",
+            "uv_forecast": "UV Forecast Summary",
+            "rain_amount_min": "Rain Amount Min.",
+            "rain_amount_max": "Rain Amount Max.",
+            "rain_amount_range": "Rain Amount Range",
+            "rain_chance": "Rain Chance",
+            "fire_danger": "Fire Danger",
+            "now_now_label": "Now Now Label",
+            "now_temp_now": "Now Temp Now",
+            "now_later_label": "Now Later Label",
+            "now_temp_later": "Now Temp Later",
+            "astronomical_sunrise_time": "Sunrise Time",
+            "astronomical_sunset_time": "Sunset Time",
         }
 
-        data_schema = vol.Schema({
-            vol.Required(CONF_FORECASTS_BASENAME, default=self.collector.locations_data["data"]["name"]): str,
-            vol.Required(CONF_FORECASTS_MONITORED): cv.multi_select(monitored),
-            vol.Required(CONF_FORECASTS_DAYS): vol.All(vol.Coerce(int), vol.Range(0, 7)),
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_FORECASTS_BASENAME,
+                    default=self.collector.locations_data["data"]["name"],
+                ): str,
+                vol.Required(CONF_FORECASTS_MONITORED): cv.multi_select(monitored),
+                vol.Required(CONF_FORECASTS_DAYS): vol.All(
+                    vol.Coerce(int), vol.Range(0, 7)
+                ),
+            }
+        )
 
         errors = {}
         if user_input is not None:
@@ -210,7 +248,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 if self.data[CONF_WARNINGS_CREATE]:
                     return await self.async_step_warnings_basename()
-                return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+                return self.async_create_entry(
+                    title=self.collector.locations_data["data"]["name"], data=self.data
+                )
 
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -225,15 +265,359 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_warnings_basename(self, user_input=None):
         """Handle the forecasts monitored step."""
-        data_schema = vol.Schema({
-            vol.Required(CONF_WARNINGS_BASENAME, default=self.collector.locations_data["data"]["name"]): str,
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_WARNINGS_BASENAME,
+                    default=self.collector.locations_data["data"]["name"],
+                ): str,
+            }
+        )
 
         errors = {}
         if user_input is not None:
             try:
                 self.data.update(user_input)
-                return self.async_create_entry(title=self.collector.locations_data["data"]["name"], data=self.data)
+                return self.async_create_entry(
+                    title=self.collector.locations_data["data"]["name"], data=self.data
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="warnings_basename", data_schema=data_schema, errors=errors
+        )
+
+
+class BomOptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialise the options flow."""
+        self.config_entry = config_entry
+        self.data = {}
+
+    async def async_step_init(self, user_input=None):
+        """Handle the initial step."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_LATITUDE,
+                    default=self.config_entry.options.get(
+                        CONF_LATITUDE,
+                        self.config_entry.data.get(
+                            CONF_LATITUDE, self.hass.config.latitude
+                        ),
+                    ),
+                ): float,
+                vol.Required(
+                    CONF_LONGITUDE,
+                    default=self.config_entry.options.get(
+                        CONF_LONGITUDE,
+                        self.config_entry.data.get(
+                            CONF_LONGITUDE, self.hass.config.longitude
+                        ),
+                    ),
+                ): float,
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                # Create the collector object with the given long. and lat.
+                self.collector = Collector(
+                    user_input[CONF_LATITUDE],
+                    user_input[CONF_LONGITUDE],
+                )
+
+                # Save the user input into self.data so it's retained
+                self.data = user_input
+
+                # Check if location is valid
+                await self.collector.get_locations_data()
+                if self.collector.locations_data is None:
+                    _LOGGER.debug(f"Unsupported Lat/Lon")
+                    errors["base"] = "bad_location"
+                else:
+                    # Populate observations and daily forecasts data
+                    await self.collector.async_update()
+
+                    # Move onto the next step of the config flow
+                    return await self.async_step_weather_name()
+
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="init", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_weather_name(self, user_input=None):
+        """Handle the locations step."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_WEATHER_NAME,
+                    default=self.config_entry.options.get(
+                        CONF_WEATHER_NAME,
+                        self.config_entry.data.get(
+                            CONF_WEATHER_NAME,
+                            self.collector.locations_data["data"]["name"],
+                        ),
+                    ),
+                ): str,
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                # Save the user input into self.data so it's retained
+                self.data.update(user_input)
+
+                return await self.async_step_sensors_create()
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="weather_name", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_sensors_create(self, user_input=None):
+        """Handle the observations step."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_OBSERVATIONS_CREATE,
+                    default=self.config_entry.options.get(
+                        CONF_OBSERVATIONS_CREATE,
+                        self.config_entry.data.get(CONF_OBSERVATIONS_CREATE, True),
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_FORECASTS_CREATE,
+                    default=self.config_entry.options.get(
+                        CONF_FORECASTS_CREATE,
+                        self.config_entry.data.get(CONF_FORECASTS_CREATE, True),
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_WARNINGS_CREATE,
+                    default=self.config_entry.options.get(
+                        CONF_WARNINGS_CREATE,
+                        self.config_entry.data.get(CONF_WARNINGS_CREATE, True),
+                    ),
+                ): bool,
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                # Save the user input into self.data so it's retained
+                self.data.update(user_input)
+
+                # Move onto the next step of the config flow
+                if self.data[CONF_OBSERVATIONS_CREATE]:
+                    return await self.async_step_observations_monitored()
+                elif self.data[CONF_FORECASTS_CREATE]:
+                    return await self.async_step_forecasts_monitored()
+                elif self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
+                else:
+                    return self.async_create_entry(
+                        title=self.collector.locations_data["data"]["name"],
+                        data=self.data,
+                    )
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="sensors_create", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_observations_monitored(self, user_input=None):
+        """Handle the observations monitored step."""
+        monitored = {
+            "temp": "Temperature",
+            "temp_feels_like": "Temperature Feels Like",
+            "rain_since_9am": "Rain Since 9am",
+            "humidity": "Humidity",
+            "wind_speed_kilometre": "Wind Speed Kilometre",
+            "wind_speed_knot": "Wind Speed Knot",
+            "wind_direction": "Wind Direction",
+            "gust_speed_kilometre": "Gust Speed Kilometre",
+            "gust_speed_knot": "Gust Speed Knot",
+        }
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_OBSERVATIONS_BASENAME,
+                    default=self.config_entry.options.get(
+                        CONF_OBSERVATIONS_BASENAME,
+                        self.config_entry.data.get(
+                            CONF_OBSERVATIONS_BASENAME,
+                            self.collector.observations_data["data"]["station"]["name"],
+                        ),
+                    ),
+                ): str,
+                vol.Required(
+                    CONF_OBSERVATIONS_MONITORED,
+                    default=self.config_entry.options.get(
+                        CONF_OBSERVATIONS_MONITORED,
+                        self.config_entry.data.get(CONF_OBSERVATIONS_MONITORED, None),
+                    ),
+                ): cv.multi_select(monitored),
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+
+                # Move onto the next step of the config flow
+                if self.data[CONF_FORECASTS_CREATE]:
+                    return await self.async_step_forecasts_monitored()
+                elif self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
+                else:
+                    return self.async_create_entry(
+                        title=self.collector.locations_data["data"]["name"],
+                        data=self.data,
+                    )
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="observations_monitored", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_forecasts_monitored(self, user_input=None):
+        """Handle the forecasts monitored step."""
+        monitored = {
+            "temp_max": "Max. Temperature",
+            "temp_min": "Min. Temperature",
+            "extended_text": "Extended Text",
+            "icon_descriptor": "Icon Descriptor",
+            "mdi_icon": "MDI Icon",
+            "short_text": "Short Text",
+            "uv_category": "UV Category",
+            "uv_max_index": "UV Max Index",
+            "uv_start_time": "UV Protection Start Time",
+            "uv_end_time": "UV Protection End Time",
+            "uv_forecast": "UV Forecast Summary",
+            "rain_amount_min": "Rain Amount Min.",
+            "rain_amount_max": "Rain Amount Max.",
+            "rain_amount_range": "Rain Amount Range",
+            "rain_chance": "Rain Chance",
+            "fire_danger": "Fire Danger",
+            "now_now_label": "Now Now Label",
+            "now_temp_now": "Now Temp Now",
+            "now_later_label": "Now Later Label",
+            "now_temp_later": "Now Temp Later",
+            "astronomical_sunrise_time": "Sunrise Time",
+            "astronomical_sunset_time": "Sunset Time",
+        }
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_FORECASTS_BASENAME,
+                    default=self.config_entry.options.get(
+                        CONF_FORECASTS_BASENAME,
+                        self.config_entry.data.get(
+                            CONF_FORECASTS_BASENAME,
+                            self.collector.locations_data["data"]["name"],
+                        ),
+                    ),
+                ): str,
+                vol.Required(
+                    CONF_FORECASTS_MONITORED,
+                    default=self.config_entry.options.get(
+                        CONF_FORECASTS_MONITORED,
+                        self.config_entry.data.get(CONF_FORECASTS_MONITORED, None),
+                    ),
+                ): cv.multi_select(monitored),
+                vol.Required(
+                    CONF_FORECASTS_DAYS,
+                    default=self.config_entry.options.get(
+                        CONF_FORECASTS_DAYS,
+                        self.config_entry.data.get(CONF_FORECASTS_DAYS, 0),
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(0, 7)),
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+
+                if self.data[CONF_WARNINGS_CREATE]:
+                    return await self.async_step_warnings_basename()
+                return self.async_create_entry(
+                    title=self.collector.locations_data["data"]["name"], data=self.data
+                )
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        return self.async_show_form(
+            step_id="forecasts_monitored", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_warnings_basename(self, user_input=None):
+        """Handle the forecasts monitored step."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_WARNINGS_BASENAME,
+                    default=self.config_entry.options.get(
+                        CONF_WARNINGS_BASENAME,
+                        self.config_entry.data.get(
+                            CONF_WARNINGS_BASENAME,
+                            self.collector.locations_data["data"]["name"],
+                        ),
+                    ),
+                ): str,
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+                return self.async_create_entry(
+                    title=self.collector.locations_data["data"]["name"], data=self.data
+                )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -1,12 +1,18 @@
 """Constants for the BOM integration."""
 
 from homeassistant.const import (
-    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_TIMESTAMP,
-    LENGTH_MILLIMETERS, PERCENTAGE, TEMP_CELSIUS,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
+    LENGTH_MILLIMETERS,
+    PERCENTAGE,
+    TEMP_CELSIUS,
 )
 
 ATTRIBUTION = "Data provided by the Australian Bureau of Meteorology"
+SHORT_ATTRIBUTION = "Australian Bureau of Meteorology"
 COLLECTOR = "collector"
+UPDATE_LISTENER = "update_listener"
 
 CONF_WEATHER_NAME = "weather_name"
 CONF_FORECASTS_BASENAME = "forecasts_basename"
@@ -23,32 +29,32 @@ COORDINATOR = "coordinator"
 DOMAIN = "bureau_of_meteorology"
 
 MAP_CONDITION = {
-    'clear': 'clear-night',
-    'cloudy': 'cloudy',
-    'cyclone': 'exceptional',
-    'dust': 'fog',
-    'dusty': 'fog',
-    'fog': 'fog',
-    'frost': 'snowy',
-    'haze': 'fog',
-    'hazy': 'fog',
-    'heavy_shower': 'rainy',
-    'heavy_showers': 'rainy',
-    'light_rain': 'rainy',
-    'light_shower': 'rainy',
-    'light_showers': 'rainy',
+    "clear": "clear-night",
+    "cloudy": "cloudy",
+    "cyclone": "exceptional",
+    "dust": "fog",
+    "dusty": "fog",
+    "fog": "fog",
+    "frost": "snowy",
+    "haze": "fog",
+    "hazy": "fog",
+    "heavy_shower": "rainy",
+    "heavy_showers": "rainy",
+    "light_rain": "rainy",
+    "light_shower": "rainy",
+    "light_showers": "rainy",
     "mostly_sunny": "sunny",
-    'partly_cloudy': 'partlycloudy',
-    'rain': 'rainy',
-    'shower': 'rainy',
-    'showers': 'rainy',
-    'snow': 'snowy',
-    'storm': 'lightning-rainy',
-    'storms': 'lightning-rainy',
-    'sunny': 'sunny',
-    'tropical_cyclone': 'exceptional',
-    'wind': 'windy',
-    'windy': 'windy',
+    "partly_cloudy": "partlycloudy",
+    "rain": "rainy",
+    "shower": "rainy",
+    "showers": "rainy",
+    "snow": "snowy",
+    "storm": "lightning-rainy",
+    "storms": "lightning-rainy",
+    "sunny": "sunny",
+    "tropical_cyclone": "exceptional",
+    "wind": "windy",
+    "windy": "windy",
     None: None,
 }
 
@@ -78,10 +84,10 @@ SENSOR_NAMES = {
     "rain_amount_range": [LENGTH_MILLIMETERS, None],
     "rain_chance": [PERCENTAGE, None],
     "fire_danger": [None, None],
-    "now_now_label":  [None, None],
-    "now_temp_now":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
-    "now_later_label":  [None, None],
-    "now_temp_later":  [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    "now_now_label": [None, None],
+    "now_temp_now": [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
+    "now_later_label": [None, None],
+    "now_temp_later": [TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE],
     "astronomical_sunrise_time": [None, DEVICE_CLASS_TIMESTAMP],
     "astronomical_sunset_time": [None, DEVICE_CLASS_TIMESTAMP],
     "warnings": [None, None],

--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -171,10 +171,6 @@ class SensorBase(Entity):
         return False
 
     @property
-    def entity_category(self) -> EntityCategory:
-        return EntityCategory.DIAGNOSTIC
-
-    @property
     def device_class(self):
         """Return the name of the sensor."""
         return SENSOR_NAMES[self.sensor_name][1]

--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -1,76 +1,164 @@
 """Platform for sensor integration."""
 import logging
 from datetime import datetime, tzinfo
-from pytz import timezone
-import pytz
+from typing import Any
+
 import iso8601
-
+import pytz
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_DATE, ATTR_STATE, DEVICE_CLASS_TIMESTAMP,
+    ATTR_ATTRIBUTION,
+    ATTR_DATE,
+    ATTR_STATE,
+    DEVICE_CLASS_TIMESTAMP,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pytz import timezone
 
+from . import BomDataUpdateCoordinator
 from .const import (
-    ATTRIBUTION, COLLECTOR, CONF_FORECASTS_BASENAME, CONF_FORECASTS_CREATE,
-    CONF_FORECASTS_DAYS, CONF_FORECASTS_MONITORED, CONF_OBSERVATIONS_BASENAME,
-    CONF_OBSERVATIONS_CREATE, CONF_OBSERVATIONS_MONITORED,
-    CONF_WARNINGS_CREATE, CONF_WARNINGS_BASENAME,
-    COORDINATOR, DOMAIN, SENSOR_NAMES,
+    ATTRIBUTION,
+    COLLECTOR,
+    CONF_FORECASTS_BASENAME,
+    CONF_FORECASTS_CREATE,
+    CONF_FORECASTS_DAYS,
+    CONF_FORECASTS_MONITORED,
+    CONF_OBSERVATIONS_BASENAME,
+    CONF_OBSERVATIONS_CREATE,
+    CONF_OBSERVATIONS_MONITORED,
+    CONF_WARNINGS_BASENAME,
+    CONF_WARNINGS_CREATE,
+    COORDINATOR,
+    DOMAIN,
+    SENSOR_NAMES,
+    SHORT_ATTRIBUTION,
 )
+from .PyBoM.collector import Collector
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Add sensors for passed config_entry in HA."""
     hass_data = hass.data[DOMAIN][config_entry.entry_id]
 
-    new_devices = []
+    new_entities = []
+    create_observations = config_entry.options.get(
+        CONF_OBSERVATIONS_CREATE, config_entry.data.get(CONF_OBSERVATIONS_CREATE)
+    )
+    create_forecasts = config_entry.options.get(
+        CONF_FORECASTS_CREATE, config_entry.data.get(CONF_FORECASTS_CREATE)
+    )
+    create_warnings = config_entry.options.get(
+        CONF_WARNINGS_CREATE, config_entry.data.get(CONF_WARNINGS_CREATE)
+    )
 
-    if config_entry.data[CONF_OBSERVATIONS_CREATE] == True:
-        for observation in config_entry.data[CONF_OBSERVATIONS_MONITORED]:
-            new_devices.append(ObservationSensor(hass_data, config_entry.data[CONF_OBSERVATIONS_BASENAME], observation))
+    if create_observations is True:
+        observation_basename = config_entry.options.get(
+            CONF_OBSERVATIONS_BASENAME,
+            config_entry.data.get(CONF_OBSERVATIONS_BASENAME),
+        )
+        observations = config_entry.options.get(
+            CONF_OBSERVATIONS_MONITORED,
+            config_entry.data.get(CONF_OBSERVATIONS_MONITORED, None),
+        )
 
-    if config_entry.data[CONF_FORECASTS_CREATE] == True:
-        days = config_entry.data[CONF_FORECASTS_DAYS]
-        for day in range(0, days+1):
-            for forecast in config_entry.data[CONF_FORECASTS_MONITORED]:
-                if forecast in ["now_now_label", "now_temp_now", "now_later_label", "now_temp_later"]:
+        for observation in observations:
+            new_entities.append(
+                ObservationSensor(
+                    hass_data,
+                    observation_basename,
+                    observation,
+                )
+            )
+
+    if create_forecasts is True:
+        forecast_basename = config_entry.options.get(
+            CONF_FORECASTS_BASENAME, config_entry.data.get(CONF_FORECASTS_BASENAME)
+        )
+        forecast_days = config_entry.options.get(
+            CONF_FORECASTS_DAYS, config_entry.data.get(CONF_FORECASTS_DAYS)
+        )
+        forecasts_monitored = config_entry.options.get(
+            CONF_FORECASTS_MONITORED, config_entry.data.get(CONF_FORECASTS_MONITORED)
+        )
+
+        for day in range(0, forecast_days + 1):
+            for forecast in forecasts_monitored:
+                if forecast in [
+                    "now_now_label",
+                    "now_temp_now",
+                    "now_later_label",
+                    "now_temp_later",
+                ]:
                     if day == 0:
-                        new_devices.append(NowLaterSensor(hass_data, config_entry.data[CONF_FORECASTS_BASENAME], forecast))
+                        new_entities.append(
+                            NowLaterSensor(
+                                hass_data,
+                                forecast_basename,
+                                forecast,
+                            )
+                        )
                 else:
-                    new_devices.append(ForecastSensor(hass_data, config_entry.data[CONF_FORECASTS_BASENAME], day, forecast))
+                    new_entities.append(
+                        ForecastSensor(
+                            hass_data,
+                            forecast_basename,
+                            day,
+                            forecast,
+                        )
+                    )
 
-    if config_entry.data.get(CONF_WARNINGS_CREATE, True) == True:
-        basename = config_entry.data.get(CONF_WARNINGS_BASENAME, None)
-        if basename is None:
-            basename = config_entry.data.get(CONF_FORECASTS_BASENAME, None)
-        if basename:
-            new_devices.append(WarningsSensor(hass_data, basename, "warnings"))
+    if create_warnings is True:
+        warnings_basename = config_entry.options.get(
+            CONF_WARNINGS_BASENAME,
+            config_entry.data.get(
+                CONF_WARNINGS_BASENAME,
+                config_entry.options.get(
+                    CONF_FORECASTS_BASENAME,
+                    config_entry.data.get(CONF_FORECASTS_BASENAME, None),
+                ),
+            ),
+        )
 
-    if new_devices:
-        async_add_devices(new_devices)
+        if warnings_basename is not None:
+            new_entities.append(
+                WarningsSensor(hass_data, warnings_basename, "warnings")
+            )
+
+    if new_entities:
+        async_add_entities(new_entities, update_before_add=False)
 
 
 class SensorBase(Entity):
     """Base representation of a BOM Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name):
+    def __init__(self, hass_data, location_name, sensor_name) -> None:
         """Initialize the sensor."""
-        self.collector = hass_data[COLLECTOR]
-        self.coordinator = hass_data[COORDINATOR]
-        self.location_name = location_name
-        self.sensor_name = sensor_name
-        self.current_state = None
+        self.collector: Collector = hass_data[COLLECTOR]
+        self.coordinator: BomDataUpdateCoordinator = hass_data[COORDINATOR]
+        self.location_name: str = location_name
+        self.sensor_name: str = sensor_name
+        self.current_state: Any = None
+
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, f"{self.location_name}")},
+            manufacturer=SHORT_ATTRIBUTION,
+            name=self.location_name,
+        )
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener and load data."""
-        self.async_on_remove(
-            self.coordinator.async_add_listener(self._update_callback)
-        )
-        self.async_on_remove(
-            self.coordinator.async_add_listener(self._update_callback)
-        )
+        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
+        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
         self._update_callback()
 
     @callback
@@ -81,6 +169,10 @@ class SensorBase(Entity):
     def should_poll(self) -> bool:
         """Entities do not individually poll."""
         return False
+
+    @property
+    def entity_category(self) -> EntityCategory:
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def device_class(self):
@@ -96,10 +188,11 @@ class SensorBase(Entity):
         """Refresh the data on the collector object."""
         await self.collector.async_update()
 
+
 class ObservationSensor(SensorBase):
     """Representation of a BOM Observation Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name):
+    def __init__(self, hass_data, location_name, sensor_name) -> None:
         """Initialize the sensor."""
         super().__init__(hass_data, location_name, sensor_name)
 
@@ -116,7 +209,13 @@ class ObservationSensor(SensorBase):
         tzinfo = pytz.timezone(self.collector.locations_data["data"]["timezone"])
         for key in self.collector.observations_data["metadata"]:
             try:
-                attr[key] = iso8601.parse_date(self.collector.observations_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                attr[key] = (
+                    iso8601.parse_date(
+                        self.collector.observations_data["metadata"][key]
+                    )
+                    .astimezone(tzinfo)
+                    .isoformat()
+                )
             except iso8601.ParseError:
                 attr[key] = self.collector.observations_data["metadata"][key]
 
@@ -129,9 +228,11 @@ class ObservationSensor(SensorBase):
         """Return the state of the sensor."""
         if self.sensor_name in self.collector.observations_data["data"]:
             if self.collector.observations_data["data"][self.sensor_name] is not None:
-                self.current_state = self.collector.observations_data["data"][self.sensor_name]
+                self.current_state = self.collector.observations_data["data"][
+                    self.sensor_name
+                ]
             else:
-                self.current_state = 'unavailable'
+                self.current_state = "unavailable"
         return self.current_state
 
     @property
@@ -163,13 +264,27 @@ class ForecastSensor(SensorBase):
             tzinfo = pytz.timezone(self.collector.locations_data["data"]["timezone"])
             for key in self.collector.daily_forecasts_data["metadata"]:
                 try:
-                    attr[key] = iso8601.parse_date(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                    attr[key] = (
+                        iso8601.parse_date(
+                            self.collector.daily_forecasts_data["metadata"][key]
+                        )
+                        .astimezone(tzinfo)
+                        .isoformat()
+                    )
                 except iso8601.ParseError:
                     attr[key] = self.collector.daily_forecasts_data["metadata"][key]
             attr[ATTR_ATTRIBUTION] = ATTRIBUTION
-            attr[ATTR_DATE] = iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
-            if self.sensor_name.startswith('extended'):
-                attr[ATTR_STATE] = self.collector.daily_forecasts_data["data"][self.day]["extended_text"]
+            attr[ATTR_DATE] = (
+                iso8601.parse_date(
+                    self.collector.daily_forecasts_data["data"][self.day]["date"]
+                )
+                .astimezone(tzinfo)
+                .isoformat()
+            )
+            if self.sensor_name.startswith("extended"):
+                attr[ATTR_STATE] = self.collector.daily_forecasts_data["data"][
+                    self.day
+                ]["extended_text"]
 
         return attr
 
@@ -178,35 +293,77 @@ class ForecastSensor(SensorBase):
         """Return the state of the sensor."""
         # If there is no data for this day, return state as 'None'.
         if self.day < len(self.collector.daily_forecasts_data["data"]):
-            if (self.device_class == DEVICE_CLASS_TIMESTAMP):
-                tzinfo = pytz.timezone(self.collector.locations_data["data"]["timezone"])
+            if self.device_class == DEVICE_CLASS_TIMESTAMP:
+                tzinfo = pytz.timezone(
+                    self.collector.locations_data["data"]["timezone"]
+                )
                 try:
-                    return iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]).astimezone(tzinfo).isoformat()
+                    return (
+                        iso8601.parse_date(
+                            self.collector.daily_forecasts_data["data"][self.day][
+                                self.sensor_name
+                            ]
+                        )
+                        .astimezone(tzinfo)
+                        .isoformat()
+                    )
                 except iso8601.ParseError:
-                    return self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
-            if (self.sensor_name == 'uv_forecast'):
-                if (self.collector.daily_forecasts_data["data"][self.day]["uv_category"] is None):
+                    return self.collector.daily_forecasts_data["data"][self.day][
+                        self.sensor_name
+                    ]
+            if self.sensor_name == "uv_forecast":
+                if (
+                    self.collector.daily_forecasts_data["data"][self.day]["uv_category"]
+                    is None
+                ):
                     return None
-                if (self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"] is None):
-                    return f'Sun protection not required, UV Index predicted to reach ' \
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} ' \
+                if (
+                    self.collector.daily_forecasts_data["data"][self.day][
+                        "uv_start_time"
+                    ]
+                    is None
+                ):
+                    return (
+                        f"Sun protection not required, UV Index predicted to reach "
+                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
                         f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
+                    )
                 else:
                     utc = pytz.utc
                     local = timezone(self.collector.locations_data["data"]["timezone"])
-                    start_time = utc.localize(datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"], '%Y-%m-%dT%H:%M:%SZ')).astimezone(local)
-                    end_time = utc.localize(datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_end_time"], '%Y-%m-%dT%H:%M:%SZ')).astimezone(local)
-                    return f'Sun protection recommended from {start_time.strftime("%-I:%M%p").lower()} to ' \
-                        f'{end_time.strftime("%-I:%M%p").lower()}, UV Index predicted to reach ' \
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} ' \
+                    start_time = utc.localize(
+                        datetime.strptime(
+                            self.collector.daily_forecasts_data["data"][self.day][
+                                "uv_start_time"
+                            ],
+                            "%Y-%m-%dT%H:%M:%SZ",
+                        )
+                    ).astimezone(local)
+                    end_time = utc.localize(
+                        datetime.strptime(
+                            self.collector.daily_forecasts_data["data"][self.day][
+                                "uv_end_time"
+                            ],
+                            "%Y-%m-%dT%H:%M:%SZ",
+                        )
+                    ).astimezone(local)
+                    return (
+                        f'Sun protection recommended from {start_time.strftime("%-I:%M%p").lower()} to '
+                        f'{end_time.strftime("%-I:%M%p").lower()}, UV Index predicted to reach '
+                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
                         f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
-            new_state = self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
+                    )
+            new_state = self.collector.daily_forecasts_data["data"][self.day][
+                self.sensor_name
+            ]
             if type(new_state) == str and len(new_state) > 251:
-                    self.current_state = new_state[:251] + '...'
+                self.current_state = new_state[:251] + "..."
             else:
                 self.current_state = new_state
-            if (self.sensor_name == 'uv_category') and (self.current_state != None):
-                self.current_state = self.current_state.replace("veryhigh", "very high").title()
+            if (self.sensor_name == "uv_category") and (self.current_state != None):
+                self.current_state = self.current_state.replace(
+                    "veryhigh", "very high"
+                ).title()
 
             return self.current_state
 
@@ -273,7 +430,9 @@ class NowLaterSensor(SensorBase):
     @property
     def state(self):
         """Return the state of the sensor."""
-        self.current_state = self.collector.daily_forecasts_data["data"][0][self.sensor_name]
+        self.current_state = self.collector.daily_forecasts_data["data"][0][
+            self.sensor_name
+        ]
         return self.current_state
 
     @property

--- a/custom_components/bureau_of_meteorology/strings.json
+++ b/custom_components/bureau_of_meteorology/strings.json
@@ -51,6 +51,58 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "latitude": "[%key:common::config_flow::data::latitude%]",
+          "longitude": "[%key:common::config_flow::data::longitude%]"
+        }
+      },
+      "weather_name": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "weather_name": "[%key:common::config_flow::data::weather_name%]"
+        }
+      },
+      "sensors_create": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "observations_create": "[%key:common::config_flow::data::observations_create%]",
+          "forecasts_create": "[%key:common::config_flow::data::forecasts_create%]",
+          "warnings_create": "[%key:common::config_flow::data::warnings_create%]"
+        }
+      },
+      "observations_monitored": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "observations_basename": "[%key:common::config_flow::data::observations_basename%]",
+          "observations_monitored": "[%key:common::config_flow::data::observations_monitored%]"
+        }
+      },
+      "forecasts_monitored": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "forecasts_basename": "[%key:common::config_flow::data::forecasts_basename%]",
+          "forecasts_monitored": "[%key:common::config_flow::data::forecasts_monitored%]",
+          "forecasts_days": "[%key:common::config_flow::data::forecasts_days%]"
+        }
+      }
+    },
+    "warnings_basename": {
+      "title": "[%key:common::config_flow::title%]",
+      "description": "[%key:common::config_flow::description%]",
+      "data": {
+        "warnings_basename": "[%key:common::config_flow::data::warnings_basename%]"
+      }
+    }
+  },
   "error": {
     "bad_location": "[%key:common::config_flow::error::bad_location%]",
     "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -60,4 +112,3 @@
     "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
   }
 }
-

--- a/custom_components/bureau_of_meteorology/translations/en.json
+++ b/custom_components/bureau_of_meteorology/translations/en.json
@@ -58,5 +58,65 @@
                 }
             }
         }
+    },
+    "options": {
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        },
+        "error": {
+            "bad_location": "Unsupported Lat/Lon",
+            "cannot_connect": "Cannot connect",
+            "unknown": "Unknown error"
+        },
+        "step": {
+            "init": {
+                "title": "Configure Australian Bureau of Meteorology",
+                "description": "Change the latitude and longitude used to find the nearest weather station.",
+                "data": {
+                    "latitude": "Latitude",
+                    "longitude": "Longitude"
+                }
+            },
+            "weather_name": {
+                "title": "Change Weather Entity Name",
+                "description": "Change the name of your BoM weather entity (eg. Warrnambool for \"weather.warrnambool\" or home for \"weather.home\").",
+                "data": {
+                    "weather_name": "Name of weather entity (weather.name)"
+                }
+            },
+            "sensors_create": {
+                "title": "Customise Additional Sensors",
+                "description": "Change which additional sensors are created for specific BoM observations, forecasts and warnings (eg. sensor.brisbane_humidity). If you wish to create any additional sensors, check the boxes below and you will be asked which sensors to create.",
+                "data": {
+                    "observations_create": "Create observation sensors?",
+                    "forecasts_create": "Create forecast sensors?",
+                    "warnings_create": "Create a sensor to hold warnings data?"
+                }
+            },
+            "observations_monitored": {
+                "title": "Change Observation Sensors",
+                "description": "You can change the basename of your observation sensors and which observation sensors you would like to create.",
+                "data": {
+                    "observations_basename": "Change the basename of the observation sensors (e.g. sensor.basename_temperature)",
+                    "observations_monitored": "Change which observation sensors to create"
+                }
+            },
+            "forecasts_monitored": {
+                "title": "Change Forecast Sensors",
+                "description": "You can change the basename of your forecast sensors, which forecast sensors you would like to create, and how many days of forecast sensors to create (day 5 is always available, day 6 and 7 are only sometimes available). Note: this can generate a lot of sensors!",
+                "data": {
+                    "forecasts_basename": "Change the basename of the forecast sensors (e.g. sensor.basename_temp_max_0)",
+                    "forecasts_monitored": "Change which forecast sensors to create",
+                    "forecasts_days": "Change the number of forecast days (0-7)"
+                }
+            },
+            "warnings_basename": {
+                "title": "Change Warnings Sensor",
+                "description": "You can change the basename of the sensor which holds the warnings data (e.g. Cairns for sensor.cairns_warnings).",
+                "data": {
+                    "warnings_basename": "Change the name of the warnings sensor"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds the ability to reconfigure the integration via the
integrations page and creates a device for each configured
base name. Each device will contain the sensors that use that
base name. Most sensors are set to diagnostic, so they won't appear
on auto-generated dashboards by default, but they can be added
by using the "Add to dashboard" option.


Signed-off-by: Avi Miller <me@dje.li>