### PR TITLE
Rename forecast() to get_forecast()

### DIFF
--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -155,7 +155,7 @@ class WeatherDaily(WeatherBase):
         return self.location_name
 
     @property
-    def forecast(self):
+    def get_forecast(self):
         """Return the forecast."""
         forecasts = []
         days = len(self.collector.daily_forecasts_data["data"])
@@ -191,7 +191,7 @@ class WeatherHourly(WeatherBase):
         return self.location_name + "_hourly"
 
     @property
-    def forecast(self):
+    def get_forecast(self):
         """Return the forecast."""
         forecasts = []
         hours = len(self.collector.hourly_forecasts_data["data"])


### PR DESCRIPTION
As per https://www.home-assistant.io/blog/2023/09/06/release-20239/#weather-forecast-service:

> With this change, the forecast attribute of the weather entity is deprecated, and will be removed in Home Assistant Core 2024.3.

This PR aims to fix this deprecation.

Closes https://github.com/bremor/bureau_of_meteorology/issues/189

cc @bremor