### PR TITLE
fix: wind direction history

### DIFF
--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -163,8 +163,6 @@ OBSERVATION_SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key=ATTR_API_WIND_DIRECTION,
         name="Wind Direction",
-        native_unit_of_measurement=DEGREE,
-        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key=ATTR_API_GUST_SPEED_KILOMETRE,


### PR DESCRIPTION
Fixes #178

**Before**

Wind direction has no information in the history.
SensorEntityDescription was incorrectly assigned a native_unit_of_measurement and a state_class; these appear to be reserved for numerical data. Ref: https://developers.home-assistant.io/docs/core/entity/sensor/

**After**

Wind direction has history information.
