### PR TITLE
Fix setup block warning

### DIFF
--- a/custom_components/bureau_of_meteorology/__init__.py
+++ b/custom_components/bureau_of_meteorology/__init__.py
@@ -81,7 +81,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     for component in PLATFORMS:
-        hass.async_create_task(
+        await hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, component)
         )
 

--- a/custom_components/bureau_of_meteorology/__init__.py
+++ b/custom_components/bureau_of_meteorology/__init__.py
@@ -80,10 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         COORDINATOR: coordinator,
     }
 
-    for component in PLATFORMS:
-        await hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     update_listener = entry.add_update_listener(async_update_options)
     hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener


### PR DESCRIPTION
Fixes #228

> Detected code that calls async_forward_entry_setup for integration bureau_of_meteorology with title: Home sensor and entry_id: 34a49ad6f5abf60a6fa407bc1551b4d4, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.