### PR TITLE
Parent initialiser argument not required

### DIFF
--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -272,7 +272,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialise the options flow."""
-        super().__init__(config_entry)
+        super().__init__()
         self.data = {}
 
     async def async_step_init(self, user_input=None):


### PR DESCRIPTION
Tested on HA Core 2025.4.1 and pre-release 1.3.4.  The initialisation doesn't need the argument.  New services added and reconfigured.