### PR TITLE
Combine Daily and Hourly Forecast into one entity

### DIFF
--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -47,14 +47,13 @@ async def async_setup_entry(
         CONF_WEATHER_NAME, config_entry.data.get(CONF_WEATHER_NAME, "Home")
     )
 
-    new_entities.append(WeatherDaily(hass_data, location_name))
-    new_entities.append(WeatherHourly(hass_data, location_name))
+    new_entities.append(BoMWeather(hass_data, location_name))
 
     if new_entities:
         async_add_entities(new_entities, update_before_add=False)
 
 
-class WeatherBase(WeatherEntity):
+class BoMWeather(WeatherEntity):
     """Base representation of a BOM weather entity."""
 
     def __init__(self, hass_data, location_name) -> None:
@@ -74,6 +73,16 @@ class WeatherBase(WeatherEntity):
         """Set up a listener and load data."""
         self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
         self._update_callback()
+
+    @property
+    def name(self):
+        """Return the name."""
+        return self.location_name
+
+    @property
+    def unique_id(self):
+        """Return Unique ID string."""
+        return self.location_name
 
     async def async_forecast_daily(self) -> list[Forecast]:
         tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
@@ -173,53 +182,5 @@ class WeatherBase(WeatherEntity):
         await self.coordinator.async_update()
 
 
-class WeatherDaily(WeatherBase):
-    """Representation of a BOM weather entity."""
-
-    def __init__(self, hass_data, location_name):
-        """Initialize the sensor."""
-        super().__init__(hass_data, location_name)
-
-    async def async_forecast_hourly(self) -> list[Forecast]:
-        # Don't implement this feature for this entity
-        raise NotImplementedError
-
-    @property
-    def supported_features(self):
-      return WeatherEntityFeature.FORECAST_DAILY
-
-    @property
-    def name(self):
-        """Return the name."""
-        return self.location_name
-
-    @property
-    def unique_id(self):
-        """Return Unique ID string."""
-        return self.location_name
 
 
-class WeatherHourly(WeatherBase):
-    """Representation of a BOM hourly weather entity."""
-
-    def __init__(self, hass_data, location_name):
-        """Initialize the sensor."""
-        super().__init__(hass_data, location_name)
-
-    async def async_forecast_daily(self) -> list[Forecast]:
-        # Don't implement this feature for this entity
-        raise NotImplementedError
-
-    @property
-    def supported_features(self):
-      return WeatherEntityFeature.FORECAST_HOURLY
-
-    @property
-    def name(self):
-        """Return the name."""
-        return self.location_name + " Hourly"
-
-    @property
-    def unique_id(self):
-        """Return Unique ID string."""
-        return self.location_name + "_hourly"


### PR DESCRIPTION
This PR aims to address issue #264 by combining the daily and hourly forcast entities into a single entity the same was the default Met.no integration does. 

It accomplishes this by doing away with the WeatherHourly and WeatherDaily classes and appending the renamed WeatherBase (renamed BoMWeather) in their place. 

This shouldn't affect any other features and I have tested by configuring the integrations with all the forecast entities enabled.

Screenshots below of test integration.

<img width="358" height="66" alt="image" src="https://github.com/user-attachments/assets/ba939f93-fbba-46fc-891e-9dcd92611c80" />

<img width="645" height="596" alt="image" src="https://github.com/user-attachments/assets/d6cd2f46-7370-4662-a7ff-8ae3ac75bbd4" />

<img width="655" height="614" alt="image" src="https://github.com/user-attachments/assets/97217844-e5e1-4a0e-9ec8-9fef5830f1af" />
