### PR TITLE
Improve BoM source selection with place/grid APIs and add setup source picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ After you have installed the custom component (see above):
 3. Search for `Bureau of Meteorology`. (If you don't see it, try refreshing your browser page to reload the cache.)
 4. Click `Submit` so add the integration.
 
+## API Source Model
+
+This integration now primarily uses BoM's newer place/grid/station APIs (`api.bom.gov.au/apikey/v1`) to match data shown on the BoM website and app.
+
+At a high level:
+
+1. A nearby `place_id` is selected during setup/options.
+2. Forecasts come from the place forecast grid (`x`, `y`) and associated text/astro endpoints.
+3. Observations come from the nearest station mapped to that place.
+4. Warnings come from coordinate-based warning endpoints.
+
+Legacy geohash (`api.weather.bom.gov.au/v1/locations/...`) remains as a compatibility fallback path, but it is no longer the primary source model.
+
 ## Troubleshooting
 
 Please set your logging for the custom_component to debug:
@@ -40,7 +53,7 @@ logger:
 
 ## Release Notes
 
-### 1.3.6 - Fix incorrect weather icons/states and adjusted timezone to match weather station location: 
+### 1.3.6 - Fix incorrect weather icons/states and adjusted timezone to match weather station location:
 - Fix 'Clear Night' shown during day and 'Sunny' shown at night. Thanks @Ay1tsMe
 - Show hourly and daily forecasts in the weather-stations local time instead of HA server's time. Thanks @Ay1tsMe
 

--- a/api doc/API.md
+++ b/api doc/API.md
@@ -1,2335 +1,370 @@
 # Bureau of Meteorology API documentation
 
-This folder contains example output of the BoM's non-documented API's. The API's are used by the BoM's mobile app as well as https://weather.bom.gov.au
+This integration uses undocumented BoM JSON APIs that back https://weather.bom.gov.au and BoM mobile clients.
 
-The are a number of different API's that all return data as json. To select the location the url's include a 7 character geohash.
+All examples below are trimmed response samples for Darwin City, Northern Territory.
 
-## Location Search
+## Current API model used by the integration
 
-This is used to fetch the geohash for a given latitude/longitude.
+Primary data is sourced from the newer place/grid/station API family under:
 
-https://api.weather.bom.gov.au/v1/locations?search=-12.463763,130.844398
+- https://api.bom.gov.au/apikey/v1
+
+### 1) Find candidate places
+
+Endpoint:
+
+- GET /locations/places/autocomplete
+
+Typical query parameters used by the integration:
+
+- name: Darwin City NT
+- limit: 5
+- website-sort: true
+- include-states: true
+- include-districts: true
+
+Sample output (trimmed):
 
 ```json
 {
-  "metadata": {
-    "response_timestamp": "2022-10-07T00:04:27Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
+  "candidates": [
+    {
+      "id": "o6051889726",
+      "coordinate": {
+        "longitude": 130.844442,
+        "latitude": -12.460834
+      },
+      "gridcells": {
+        "forecast": {
+          "x": 316,
+          "y": 651
+        }
+      },
+      "name": "Darwin City",
+      "state": "NT",
+      "timezone": "Australia/Darwin",
+      "type": "place"
+    }
+  ]
+}
+```
+
+### 2) Resolve canonical place details
+
+Endpoint:
+
+- GET /locations/places/details/place/{place_id}
+
+Example URL values:
+
+- place_id: o6051889726
+- filter: nearby_type:bom_stn,elevation:300,capability:SENSOR_TEMPERATURE_DB,match_coastal_status:true
+- radius: 100000
+- nearby_limit: 10
+
+Sample output (trimmed):
+
+```json
+{
+  "place": {
+    "id": "o6051889726",
+    "name": "Darwin City",
+    "timezone": "Australia/Darwin",
+    "coordinate": {
+      "longitude": 130.844442,
+      "latitude": -12.460834
+    },
+    "gridcells": {
+      "forecast": {
+        "x": 316,
+        "y": 651
+      }
+    },
+    "location_hierarchy": {
+      "metropolitan": [
+        {
+          "aac": "NT_ME006",
+          "description": "Darwin"
+        },
+        {
+          "aac": "NT_ME001",
+          "description": "Darwin Area"
+        }
+      ],
+      "precis_fcst": {
+        "aac": "NT_PT001",
+        "description": "Darwin"
+      },
+      "nearest": {
+        "id": "14072",
+        "name": "Darwin Harbour",
+        "type": "bom_stn",
+        "distance": 1239.288
+      },
+      "nearby": [
+        {
+          "id": "14318",
+          "name": "East Point",
+          "distance": 5866.6597
+        },
+        {
+          "id": "14015",
+          "name": "Darwin Airport",
+          "distance": 6640.5645
+        }
+      ]
+    }
+  }
+}
+```
+
+### 3) Forecast data (grid-based)
+
+Endpoints:
+
+- GET /forecasts/daily/{x}/{y}?timezone={timezone}
+- GET /forecasts/1hourly/{x}/{y}?timezone={timezone}
+- GET /forecasts/3hourly/{x}/{y}?timezone={timezone}
+- GET /forecasts/astro/{lon}/{lat}
+- GET /forecasts/texts?aac={aac}&timezone={timezone}
+
+Example values for Darwin City:
+
+- x: 316
+- y: 651
+- timezone: Australia/Darwin
+- lon/lat: 130.844442, -12.460834
+- text aac (area): NT_ME001
+
+Daily sample output (trimmed):
+
+```json
+{
+  "meta": {
+    "issue_time_utc": "2026-07-21T10:33:26Z",
+    "issue_time_next_utc": "2026-07-21T20:00:00Z",
+    "local_timezone": "Australia/Darwin"
   },
+  "fcst": {
+    "daily": [
+      {
+        "date_utc": "2026-07-21T14:30:00Z",
+        "atm": {
+          "surf_air": {
+            "temp_max_cel": 30.800001,
+            "temp_min_cel": 18.0,
+            "precip": {
+              "any_probability_percent": 2.0,
+              "exceeding_50percentchance_total_mm": 0.0
+            },
+            "weather": {
+              "icon_code": 1
+            },
+            "radiation": {
+              "uv_clear_sky_max_code": 8.993267,
+              "uv_period_start": "2026-07-22T00:10:00Z",
+              "uv_period_end": "2026-07-22T06:30:00Z"
+            }
+          }
+        },
+        "astro": {
+          "sunrise_utc": null,
+          "sunset_utc": null
+        }
+      }
+    ]
+  }
+}
+```
+
+1-hourly sample output (trimmed):
+
+```json
+{
+  "meta": {
+    "issue_time_utc": "2026-07-21T10:50:02Z",
+    "local_timezone": "Australia/Darwin"
+  },
+  "fcst": [
+    {
+      "date_utc": "2026-07-21T14:30:00Z",
+      "1hourly": [
+        {
+          "time_utc": "2026-07-21T15:00:00Z",
+          "atm": {
+            "surf_air": {
+              "temp_cel": 18.4,
+              "temp_apparent_cel": 19.7,
+              "hum_relative_percent": 97.5,
+              "wind": {
+                "dirn_10m_deg_t": 182.3,
+                "speed_10m_avg_mps": 2.222,
+                "gust_speed_10m_max_mps": 3.601
+              },
+              "radiation": {
+                "uv_clear_sky_code": 0.0
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Astro sample output (trimmed):
+
+```json
+{
+  "meta": {
+    "local_timezone": "Australia/Darwin"
+  },
+  "fcst": {
+    "daily": [
+      {
+        "date_utc": "2026-07-21T14:30:00Z",
+        "astro": {
+          "sunrise_utc": "2026-07-21T21:38:16Z",
+          "sunset_utc": "2026-07-22T09:08:10Z"
+        }
+      }
+    ]
+  }
+}
+```
+
+Forecast text sample output (trimmed):
+
+```json
+{
+  "meta": {
+    "issue_time_utc": "2026-07-21T10:45:26Z",
+    "local_timezone": "Australia/Darwin"
+  },
+  "fcst": {
+    "daily": [
+      {
+        "date_utc": "2026-07-21T14:30:00Z",
+        "atm": {
+          "surf_air": {
+            "radiation": {
+              "advice_summary": {
+                "metropolitan_text": "Sun protection 9:40am to 4:00pm, UV Index predicted to reach 8 [Very High]"
+              }
+            },
+            "weather": {
+              "metropolitan_text": "Sunny. Light winds becoming east to southeasterly 15 to 20 km/h in the morning then becoming light in the middle of the day."
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### 4) Observations data (station-based)
+
+Endpoint:
+
+- GET /observations/latest/{station_id}/atm/surf_air?include_qc_results=false
+
+Darwin station example used for sample:
+
+- station_id: 14015 (Darwin Airport)
+
+Sample output (trimmed):
+
+```json
+{
+  "stn": {
+    "identity": {
+      "bom_stn_num": 14015,
+      "bom_stn_name": "Darwin Airport",
+      "wmo_stn_id": 94120
+    },
+    "location": {
+      "lat_dec_deg": -12.4239,
+      "long_dec_deg": 130.8925,
+      "timezone": "Australia/Darwin"
+    }
+  },
+  "obs": {
+    "datetime_utc": "2026-07-21T11:00:00Z",
+    "temp": {
+      "dry_bulb_1min_cel": 23.6,
+      "apparent_1min_cel": 26.21,
+      "dry_bulb_max_cel": 30.0,
+      "dry_bulb_min_cel": 23.5,
+      "rel_hum_percent": 80.0
+    },
+    "wind": {
+      "speed_10m_mps": 1.646,
+      "dirn_10m_ord": "WSW",
+      "gust_speed_10m_max_mps": 8.231
+    },
+    "precip": {
+      "since_0900lct_total_mm": 0.0
+    }
+  }
+}
+```
+
+### 5) Warnings data (coordinate-based)
+
+Endpoint:
+
+- GET /warnings/list?area_type=coordinate&area_code={lon},{lat}
+
+Note: coordinates are expected with up to 2 decimal places.
+
+Darwin example request values:
+
+- area_code: 130.84,-12.46
+
+Sample output:
+
+```json
+{
+  "warnings": []
+}
+```
+
+## Integration data flow
+
+1. Setup/options resolves top candidate places near configured coordinates.
+2. Selected place_id is stored in config data.
+3. Forecasts load from place forecast grid (x,y) and text/astro endpoints.
+4. Observations use a station endpoint (and may fall back if needed).
+5. Warnings load from coordinate warnings endpoint.
+
+## Legacy geohash fallback
+
+Geohash endpoints are no longer the primary model.
+
+They are still retained as a compatibility fallback path when place-based calls are unavailable or when user-selected source behavior requires it.
+
+Legacy endpoint family:
+
+- https://api.weather.bom.gov.au/v1/locations/{geohash}
+- .../observations
+- .../forecasts/daily
+- .../forecasts/hourly
+- .../warnings
+
+Legacy location-search sample (Darwin City):
+
+```json
+{
   "data": [
     {
       "geohash": "qvv117j",
       "id": "Darwin City-qvv117j",
       "name": "Darwin City",
-      "postcode": null,
       "state": "NT"
     }
   ]
 }
 ```
-
-## Location Info
-
-This returns a set of information for the given geohash.
-
-https://api.weather.bom.gov.au/v1/locations/{geohash}
-
-```json
-{
-  "metadata": {
-    "response_timestamp": "2022-10-07T00:27:52Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  },
-  "data": {
-    "geohash": "qvv117n",
-    "timezone": "Australia/Darwin",
-    "latitude": -12.463302612304688,
-    "longitude": 130.84510803222656,
-    "marine_area_id": "NT_MW007",
-    "tidal_point": "NT_TP001",
-    "has_wave": true,
-    "id": "Darwin City-qvv117n",
-    "name": "Darwin City",
-    "state": "NT"
-  }
-}
-```
-
-## Observations
-
-This returns the observation from the nearest monitoring station.
-
-https://api.weather.bom.gov.au/v1/locations/{geohash}/observations
-
-```json
-{
-  "metadata": {
-    "response_timestamp": "2022-10-07T00:19:26Z",
-    "issue_time": "2022-10-07T00:11:02Z",
-    "observation_time": "2022-10-07T00:10:00Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  },
-  "data": {
-    "temp": 30.5,
-    "temp_feels_like": 33.6,
-    "wind": {
-      "speed_kilometre": 11,
-      "speed_knot": 6,
-      "direction": "SW"
-    },
-    "gust": {
-      "speed_kilometre": 13,
-      "speed_knot": 7
-    },
-    "max_gust": {
-      "speed_kilometre": 20,
-      "speed_knot": 11,
-      "time": "2022-10-06T16:43:00Z"
-    },
-    "max_temp": {
-      "time": "2022-10-07T00:01:00Z",
-      "value": 30.7
-    },
-    "min_temp": {
-      "time": "2022-10-06T20:57:00Z",
-      "value": 25.5
-    },
-    "rain_since_9am": 0,
-    "humidity": 64,
-    "station": {
-      "bom_id": "014015",
-      "name": "Darwin Airport",
-      "distance": 6899
-    }
-  }
-}
-```
-
-## Daily forecasts
-
-This returns the daily forecasts for the given geohash.
-
-https://api.weather.bom.gov.au/v1/locations/{geohash}/forecasts/daily
-
-```json
-{
-  "data": [
-    {
-      "rain": {
-        "amount": {
-          "min": 1,
-          "max": 4,
-          "lower_range": 0,
-          "upper_range": 4,
-          "units": "mm"
-        },
-        "chance": 70,
-        "precipitation_amount_25_percent_chance": 4,
-        "precipitation_amount_50_percent_chance": 1,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": "extreme",
-        "end_time": "2022-10-07T06:50:00Z",
-        "max_index": 12,
-        "start_time": "2022-10-06T23:20:00Z"
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-06T20:57:40Z",
-        "sunset_time": "2022-10-07T09:13:56Z"
-      },
-      "date": "2022-10-06T14:30:00Z",
-      "temp_max": 34,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. Medium chance of showers. The chance of a thunderstorm. Light winds becoming northwesterly 15 to 25 km/h in the middle of the day then tending westerly in the evening.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": "High",
-      "fire_danger": "High",
-      "fire_danger_category": {
-        "text": "High",
-        "default_colour": "#fedd3a",
-        "dark_mode_colour": "#fedd3a"
-      },
-      "now": {
-        "is_night": false,
-        "now_label": "Max",
-        "later_label": "Overnight Min",
-        "temp_now": 34,
-        "temp_later": 25
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 3,
-          "max": 10,
-          "lower_range": 0,
-          "upper_range": 10,
-          "units": "mm"
-        },
-        "chance": 70,
-        "precipitation_amount_25_percent_chance": 10,
-        "precipitation_amount_50_percent_chance": 3,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": "extreme",
-        "end_time": "2022-10-08T06:50:00Z",
-        "max_index": 13,
-        "start_time": "2022-10-07T23:20:00Z"
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-07T20:57:01Z",
-        "sunset_time": "2022-10-08T09:13:59Z"
-      },
-      "date": "2022-10-07T14:30:00Z",
-      "temp_max": 34,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. High chance of showers. The chance of a thunderstorm. Light winds becoming northwesterly 15 to 20 km/h in the early afternoon then becoming light in the late afternoon.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": "Moderate",
-      "fire_danger_category": {
-        "text": "Moderate",
-        "default_colour": "#64bf30",
-        "dark_mode_colour": "#64bf30"
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 6,
-          "max": 15,
-          "lower_range": 2,
-          "upper_range": 15,
-          "units": "mm"
-        },
-        "chance": 80,
-        "precipitation_amount_25_percent_chance": 15,
-        "precipitation_amount_50_percent_chance": 6,
-        "precipitation_amount_75_percent_chance": 2
-      },
-      "uv": {
-        "category": "extreme",
-        "end_time": "2022-10-09T06:50:00Z",
-        "max_index": 13,
-        "start_time": "2022-10-08T23:10:00Z"
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-08T20:56:23Z",
-        "sunset_time": "2022-10-09T09:14:02Z"
-      },
-      "date": "2022-10-08T14:30:00Z",
-      "temp_max": 34,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. High chance of showers. The chance of a thunderstorm. Light winds.",
-      "icon_descriptor": "storm",
-      "short_text": "Showers. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": "Moderate",
-      "fire_danger_category": {
-        "text": "Moderate",
-        "default_colour": "#64bf30",
-        "dark_mode_colour": "#64bf30"
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 1,
-          "max": 6,
-          "lower_range": 0,
-          "upper_range": 6,
-          "units": "mm"
-        },
-        "chance": 70,
-        "precipitation_amount_25_percent_chance": 6,
-        "precipitation_amount_50_percent_chance": 1,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": "extreme",
-        "end_time": "2022-10-10T06:50:00Z",
-        "max_index": 14,
-        "start_time": "2022-10-09T23:10:00Z"
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-09T20:55:46Z",
-        "sunset_time": "2022-10-10T09:14:06Z"
-      },
-      "date": "2022-10-09T14:30:00Z",
-      "temp_max": 35,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. High chance of showers, most likely in the morning. The chance of a thunderstorm. Light winds becoming northwest to northeasterly 15 to 20 km/h during the afternoon then becoming light during the evening.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": "High",
-      "fire_danger_category": {
-        "text": "High",
-        "default_colour": "#fedd3a",
-        "dark_mode_colour": "#fedd3a"
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 2,
-          "max": 8,
-          "lower_range": 0,
-          "upper_range": 8,
-          "units": "mm"
-        },
-        "chance": 70,
-        "precipitation_amount_25_percent_chance": 8,
-        "precipitation_amount_50_percent_chance": 2,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": null,
-        "end_time": null,
-        "max_index": null,
-        "start_time": null
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-10T20:55:09Z",
-        "sunset_time": "2022-10-11T09:14:10Z"
-      },
-      "date": "2022-10-10T14:30:00Z",
-      "temp_max": 33,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. High chance of showers, most likely during the morning. The chance of a thunderstorm. Light winds becoming west to northwesterly 15 to 20 km/h during the day.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": null,
-      "fire_danger_category": {
-        "text": null,
-        "default_colour": null,
-        "dark_mode_colour": null
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 3,
-          "max": 8,
-          "lower_range": 0,
-          "upper_range": 8,
-          "units": "mm"
-        },
-        "chance": 70,
-        "precipitation_amount_25_percent_chance": 8,
-        "precipitation_amount_50_percent_chance": 3,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": null,
-        "end_time": null,
-        "max_index": null,
-        "start_time": null
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-11T20:54:33Z",
-        "sunset_time": "2022-10-12T09:14:15Z"
-      },
-      "date": "2022-10-11T14:30:00Z",
-      "temp_max": 33,
-      "temp_min": 25,
-      "extended_text": "Partly cloudy. High chance of showers, most likely during the morning. The chance of a thunderstorm. Light winds becoming westerly 15 to 20 km/h during the day.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": null,
-      "fire_danger_category": {
-        "text": null,
-        "default_colour": null,
-        "dark_mode_colour": null
-      }
-    },
-    {
-      "rain": {
-        "amount": {
-          "min": 1,
-          "max": 4,
-          "lower_range": 0,
-          "upper_range": 4,
-          "units": "mm"
-        },
-        "chance": 60,
-        "precipitation_amount_25_percent_chance": 4,
-        "precipitation_amount_50_percent_chance": 1,
-        "precipitation_amount_75_percent_chance": 0
-      },
-      "uv": {
-        "category": null,
-        "end_time": null,
-        "max_index": null,
-        "start_time": null
-      },
-      "astronomical": {
-        "sunrise_time": "2022-10-12T20:53:57Z",
-        "sunset_time": "2022-10-13T09:14:20Z"
-      },
-      "date": "2022-10-12T14:30:00Z",
-      "temp_max": 33,
-      "temp_min": 26,
-      "extended_text": "Partly cloudy. Medium chance of showers. The chance of a thunderstorm. Light winds.",
-      "icon_descriptor": "storm",
-      "short_text": "Shower or two. Possible storm.",
-      "surf_danger": null,
-      "fire_danger": null,
-      "fire_danger_category": {
-        "text": null,
-        "default_colour": null,
-        "dark_mode_colour": null
-      }
-    }
-  ],
-  "metadata": {
-    "response_timestamp": "2022-10-07T00:25:37Z",
-    "issue_time": "2022-10-07T00:00:16Z",
-    "next_issue_time": "2022-10-07T06:30:00Z",
-    "forecast_region": "Darwin",
-    "forecast_type": "precis",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  }
-}
-```
-
-## Hourly forecasts
-
-This returns the hourly forecasts for the given geohash.
-
-https://api.weather.bom.gov.au/v1/locations/{geohas}/forecasts/hourly
-
-```json
-{
-  "metadata": {
-    "issue_time": "2022-10-07T00:05:13Z",
-    "response_timestamp": "2022-10-07T00:41:49Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  },
-  "data": [
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "SSE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 71,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T03:00:00Z",
-      "time": "2022-10-07T00:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T01:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "SSW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 66,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T03:00:00Z",
-      "time": "2022-10-07T01:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T02:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 5,
-        "speed_kilometre": 9,
-        "direction": "W",
-        "gust_speed_knot": 8,
-        "gust_speed_kilometre": 15
-      },
-      "relative_humidity": 65,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T03:00:00Z",
-      "time": "2022-10-07T02:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T03:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 5,
-        "speed_kilometre": 9,
-        "direction": "NW",
-        "gust_speed_knot": 9,
-        "gust_speed_kilometre": 17
-      },
-      "relative_humidity": 66,
-      "uv": 12,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T06:00:00Z",
-      "time": "2022-10-07T03:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T04:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 32,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 9,
-        "speed_kilometre": 17,
-        "direction": "NW",
-        "gust_speed_knot": 14,
-        "gust_speed_kilometre": 26
-      },
-      "relative_humidity": 65,
-      "uv": 12,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T06:00:00Z",
-      "time": "2022-10-07T04:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T05:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 9,
-        "speed_kilometre": 17,
-        "direction": "NW",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 61,
-      "uv": 12,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T06:00:00Z",
-      "time": "2022-10-07T05:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T06:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 9,
-        "speed_kilometre": 17,
-        "direction": "NW",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 60,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T09:00:00Z",
-      "time": "2022-10-07T06:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T07:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 9,
-        "speed_kilometre": 17,
-        "direction": "NW",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 57,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T09:00:00Z",
-      "time": "2022-10-07T07:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T08:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 34,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "NW",
-        "gust_speed_knot": 12,
-        "gust_speed_kilometre": 22
-      },
-      "relative_humidity": 55,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T09:00:00Z",
-      "time": "2022-10-07T08:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T09:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "NW",
-        "gust_speed_knot": 12,
-        "gust_speed_kilometre": 22
-      },
-      "relative_humidity": 58,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T12:00:00Z",
-      "time": "2022-10-07T09:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T10:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "WNW",
-        "gust_speed_knot": 11,
-        "gust_speed_kilometre": 20
-      },
-      "relative_humidity": 66,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T12:00:00Z",
-      "time": "2022-10-07T10:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T11:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "W",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 70,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T12:00:00Z",
-      "time": "2022-10-07T11:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T12:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "W",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 72,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T15:00:00Z",
-      "time": "2022-10-07T12:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T13:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WNW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 74,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T15:00:00Z",
-      "time": "2022-10-07T13:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T14:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WNW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 77,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-07T15:00:00Z",
-      "time": "2022-10-07T14:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T15:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 30,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WNW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 77,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T18:00:00Z",
-      "time": "2022-10-07T15:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T16:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 30,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "W",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 80,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T18:00:00Z",
-      "time": "2022-10-07T16:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T17:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 30,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "W",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 82,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T18:00:00Z",
-      "time": "2022-10-07T17:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T18:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WSW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 83,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T21:00:00Z",
-      "time": "2022-10-07T18:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T19:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "S",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 86,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T21:00:00Z",
-      "time": "2022-10-07T19:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T20:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 25,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "S",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 94,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-07T21:00:00Z",
-      "time": "2022-10-07T20:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-07T21:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "S",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 90,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T00:00:00Z",
-      "time": "2022-10-07T21:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T22:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SSE",
-        "gust_speed_knot": 5,
-        "gust_speed_kilometre": 9
-      },
-      "relative_humidity": 91,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T00:00:00Z",
-      "time": "2022-10-07T22:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-07T23:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SSE",
-        "gust_speed_knot": 5,
-        "gust_speed_kilometre": 9
-      },
-      "relative_humidity": 83,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T00:00:00Z",
-      "time": "2022-10-07T23:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T00:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SSE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 74,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T03:00:00Z",
-      "time": "2022-10-08T00:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T01:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "NE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 71,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T03:00:00Z",
-      "time": "2022-10-08T01:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T02:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 5,
-        "speed_kilometre": 9,
-        "direction": "NNE",
-        "gust_speed_knot": 8,
-        "gust_speed_kilometre": 15
-      },
-      "relative_humidity": 68,
-      "uv": 5,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T03:00:00Z",
-      "time": "2022-10-08T02:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T03:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 5,
-        "speed_kilometre": 9,
-        "direction": "NNW",
-        "gust_speed_knot": 8,
-        "gust_speed_kilometre": 15
-      },
-      "relative_humidity": 67,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T06:00:00Z",
-      "time": "2022-10-08T03:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T04:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 32,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "NNW",
-        "gust_speed_knot": 11,
-        "gust_speed_kilometre": 20
-      },
-      "relative_humidity": 65,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T06:00:00Z",
-      "time": "2022-10-08T04:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T05:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "NNW",
-        "gust_speed_knot": 12,
-        "gust_speed_kilometre": 22
-      },
-      "relative_humidity": 62,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T06:00:00Z",
-      "time": "2022-10-08T05:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T06:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "NW",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 61,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T09:00:00Z",
-      "time": "2022-10-08T06:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T07:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 34,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 9,
-        "speed_kilometre": 17,
-        "direction": "WNW",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 58,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T09:00:00Z",
-      "time": "2022-10-08T07:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T08:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 34,
-      "temp_feels_like": 37,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "WNW",
-        "gust_speed_knot": 11,
-        "gust_speed_kilometre": 20
-      },
-      "relative_humidity": 58,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T09:00:00Z",
-      "time": "2022-10-08T08:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T09:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "W",
-        "gust_speed_knot": 11,
-        "gust_speed_kilometre": 20
-      },
-      "relative_humidity": 62,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T12:00:00Z",
-      "time": "2022-10-08T09:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T10:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "W",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 69,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T12:00:00Z",
-      "time": "2022-10-08T10:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T11:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 10,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "W",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 72,
-      "uv": 0,
-      "icon_descriptor": "mostly_sunny",
-      "next_three_hourly_forecast_period": "2022-10-08T12:00:00Z",
-      "time": "2022-10-08T11:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T12:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "W",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 75,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T15:00:00Z",
-      "time": "2022-10-08T12:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T13:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WNW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 78,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T15:00:00Z",
-      "time": "2022-10-08T13:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T14:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "NNW",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 80,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T15:00:00Z",
-      "time": "2022-10-08T14:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T15:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "NNE",
-        "gust_speed_knot": 5,
-        "gust_speed_kilometre": 9
-      },
-      "relative_humidity": 79,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T18:00:00Z",
-      "time": "2022-10-08T15:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T16:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "NNE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 80,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T18:00:00Z",
-      "time": "2022-10-08T16:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T17:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "NE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 81,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T18:00:00Z",
-      "time": "2022-10-08T17:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T18:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "NNE",
-        "gust_speed_knot": 8,
-        "gust_speed_kilometre": 15
-      },
-      "relative_humidity": 82,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T21:00:00Z",
-      "time": "2022-10-08T18:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T19:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "E",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 83,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T21:00:00Z",
-      "time": "2022-10-08T19:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T20:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 60,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "E",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 88,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-08T21:00:00Z",
-      "time": "2022-10-08T20:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-08T21:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "SE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 87,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T00:00:00Z",
-      "time": "2022-10-08T21:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T22:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 25,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "ESE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 92,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T00:00:00Z",
-      "time": "2022-10-08T22:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-08T23:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 4,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "ESE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 90,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T00:00:00Z",
-      "time": "2022-10-08T23:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T00:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 5,
-        "speed_kilometre": 9,
-        "direction": "ESE",
-        "gust_speed_knot": 8,
-        "gust_speed_kilometre": 15
-      },
-      "relative_humidity": 83,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T03:00:00Z",
-      "time": "2022-10-09T00:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T01:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 6,
-        "speed_kilometre": 11,
-        "direction": "NE",
-        "gust_speed_knot": 9,
-        "gust_speed_kilometre": 17
-      },
-      "relative_humidity": 72,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T03:00:00Z",
-      "time": "2022-10-09T01:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T02:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "NE",
-        "gust_speed_knot": 10,
-        "gust_speed_kilometre": 19
-      },
-      "relative_humidity": 68,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T03:00:00Z",
-      "time": "2022-10-09T02:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T03:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 6,
-        "speed_kilometre": 11,
-        "direction": "NNE",
-        "gust_speed_knot": 9,
-        "gust_speed_kilometre": 17
-      },
-      "relative_humidity": 65,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T06:00:00Z",
-      "time": "2022-10-09T03:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T04:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 32,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "NNE",
-        "gust_speed_knot": 13,
-        "gust_speed_kilometre": 24
-      },
-      "relative_humidity": 62,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T06:00:00Z",
-      "time": "2022-10-09T04:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T05:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 37,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "N",
-        "gust_speed_knot": 12,
-        "gust_speed_kilometre": 22
-      },
-      "relative_humidity": 57,
-      "uv": 13,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T06:00:00Z",
-      "time": "2022-10-09T05:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T06:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 8,
-        "speed_kilometre": 15,
-        "direction": "N",
-        "gust_speed_knot": 12,
-        "gust_speed_kilometre": 22
-      },
-      "relative_humidity": 56,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T09:00:00Z",
-      "time": "2022-10-09T06:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T07:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 34,
-      "temp_feels_like": 37,
-      "wind": {
-        "speed_knot": 7,
-        "speed_kilometre": 13,
-        "direction": "N",
-        "gust_speed_knot": 11,
-        "gust_speed_kilometre": 20
-      },
-      "relative_humidity": 56,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T09:00:00Z",
-      "time": "2022-10-09T07:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T08:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 34,
-      "temp_feels_like": 37,
-      "wind": {
-        "speed_knot": 6,
-        "speed_kilometre": 11,
-        "direction": "WNW",
-        "gust_speed_knot": 10,
-        "gust_speed_kilometre": 19
-      },
-      "relative_humidity": 56,
-      "uv": 5,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T09:00:00Z",
-      "time": "2022-10-09T08:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T09:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 33,
-      "temp_feels_like": 36,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "WSW",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 61,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T12:00:00Z",
-      "time": "2022-10-09T09:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T10:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 31,
-      "temp_feels_like": 35,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SW",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 70,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T12:00:00Z",
-      "time": "2022-10-09T10:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T11:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 30,
-      "temp_feels_like": 34,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SSW",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 74,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T12:00:00Z",
-      "time": "2022-10-09T11:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T12:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "S",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 75,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T15:00:00Z",
-      "time": "2022-10-09T12:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T13:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 2,
-        "speed_kilometre": 4,
-        "direction": "SE",
-        "gust_speed_knot": 5,
-        "gust_speed_kilometre": 9
-      },
-      "relative_humidity": 78,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T15:00:00Z",
-      "time": "2022-10-09T13:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T14:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 50,
-        "precipitation_amount_10_percent_chance": 2,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "ENE",
-        "gust_speed_knot": 5,
-        "gust_speed_kilometre": 9
-      },
-      "relative_humidity": 81,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T15:00:00Z",
-      "time": "2022-10-09T14:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T15:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 27,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "NE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 83,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T18:00:00Z",
-      "time": "2022-10-09T15:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T16:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "ENE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 85,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T18:00:00Z",
-      "time": "2022-10-09T16:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T17:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": 1, "units": "mm" },
-        "chance": 40,
-        "precipitation_amount_10_percent_chance": 3,
-        "precipitation_amount_25_percent_chance": 1,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "ENE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 87,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T18:00:00Z",
-      "time": "2022-10-09T17:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T18:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 25,
-      "temp_feels_like": 29,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "ENE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 89,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T21:00:00Z",
-      "time": "2022-10-09T18:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T19:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 25,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 89,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T21:00:00Z",
-      "time": "2022-10-09T19:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T20:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 20,
-        "precipitation_amount_10_percent_chance": 1,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 25,
-      "temp_feels_like": 29,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 90,
-      "uv": 0,
-      "icon_descriptor": "storm",
-      "next_three_hourly_forecast_period": "2022-10-09T21:00:00Z",
-      "time": "2022-10-09T20:00:00Z",
-      "is_night": true,
-      "next_forecast_period": "2022-10-09T21:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 5,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 30,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 87,
-      "uv": 0,
-      "icon_descriptor": "sunny",
-      "next_three_hourly_forecast_period": "2022-10-10T00:00:00Z",
-      "time": "2022-10-09T21:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T22:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 5,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 26,
-      "temp_feels_like": 31,
-      "wind": {
-        "speed_knot": 3,
-        "speed_kilometre": 6,
-        "direction": "SE",
-        "gust_speed_knot": 6,
-        "gust_speed_kilometre": 11
-      },
-      "relative_humidity": 87,
-      "uv": 0,
-      "icon_descriptor": "sunny",
-      "next_three_hourly_forecast_period": "2022-10-10T00:00:00Z",
-      "time": "2022-10-09T22:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-09T23:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 5,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 28,
-      "temp_feels_like": 32,
-      "wind": {
-        "speed_knot": 4,
-        "speed_kilometre": 7,
-        "direction": "SE",
-        "gust_speed_knot": 7,
-        "gust_speed_kilometre": 13
-      },
-      "relative_humidity": 80,
-      "uv": 0,
-      "icon_descriptor": "sunny",
-      "next_three_hourly_forecast_period": "2022-10-10T00:00:00Z",
-      "time": "2022-10-09T23:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-10T00:00:00Z"
-    },
-    {
-      "rain": {
-        "amount": { "min": 0, "max": null, "units": "mm" },
-        "chance": 5,
-        "precipitation_amount_10_percent_chance": 0,
-        "precipitation_amount_25_percent_chance": 0,
-        "precipitation_amount_50_percent_chance": 0
-      },
-      "temp": 29,
-      "temp_feels_like": 33,
-      "wind": {
-        "speed_knot": 6,
-        "speed_kilometre": 11,
-        "direction": "SE",
-        "gust_speed_knot": 10,
-        "gust_speed_kilometre": 19
-      },
-      "relative_humidity": 70,
-      "uv": 6,
-      "icon_descriptor": "sunny",
-      "next_three_hourly_forecast_period": "2022-10-10T03:00:00Z",
-      "time": "2022-10-10T00:00:00Z",
-      "is_night": false,
-      "next_forecast_period": "2022-10-10T01:00:00Z"
-    }
-  ]
-}
-```
-
-## Warnings
-
-This returns the warnings for the given geohash.
-
-https://api.weather.bom.gov.au/v1/locations/{geohash}/warnings
-
-```json
-{
-  "data": [
-    {
-      "id": "NSW_FL049_IDN36503",
-      "type": "flood_watch",
-      "title": "Flood Watch for Queanbeyan and Molonglo Rivers",
-      "short_title": "Flood Watch",
-      "state": "NSW",
-      "warning_group_type": "major",
-      "issue_time": "2022-10-07T00:18:46Z",
-      "expiry_time": "2022-10-08T06:18:46Z",
-      "phase": "renewal"
-    },
-    {
-      "id": "NSW_PW017_IDN29000",
-      "type": "sheep_graziers_warning",
-      "title": "Sheep Graziers Warning for Australian Capital Territory forecast district",
-      "short_title": "Sheep Graziers Warning",
-      "state": "NSW",
-      "warning_group_type": "minor",
-      "issue_time": "2022-10-07T00:21:57Z",
-      "expiry_time": "2022-10-07T08:21:57Z",
-      "phase": "renewal"
-    }
-  ],
-  "metadata": {
-    "response_timestamp": "2022-10-07T01:08:55Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  }
-}
-```
-
-Once you have the warning summary it is possible to get detailed info for the warning using this url.
-
-https://api.weather.bom.gov.au/v1/warnings/{id}
-
-```json
-{
-  "metadata": {
-    "issue_time": "2022-10-09T00:00:41Z",
-    "response_timestamp": "2022-10-09T00:03:12Z",
-    "copyright": "This Application Programming Interface (API) is owned by the Bureau of Meteorology (Bureau). You must not use, copy or share it. Please contact us for more information on ways in which you can access our data. Follow this link http://www.bom.gov.au/inside/contacts.shtml to view our contact details."
-  },
-  "data": {
-    "id": "NSW_RC072_IDN36627",
-    "type": "flood_warning",
-    "title": "Flood Warning for Molonglo River",
-    "short_title": "Flood Warning",
-    "state": "NSW",
-    "message": "<div class=\"product\">\n<p class=\"p-id\">IDN36627</p>Australian Government Bureau of Meteorology<h2>Minor Flood Warning for the Queanbeyan and Molonglo Rivers</h2>\n<p class=\"date\">Issued at 11:00 am EDT on Sunday 9 October 2022</p>\n<p>Flood Warning Number: 3</p>\n<p>MINOR FLOODING OCCURRING AT QUEANBEYAN AND OAKS ESTATE</p>\n<p>Heavy rainfall in the last several days in the Queanbeyan and  Molonglo River catchments have caused stream rises, and minor flooding is occurring in the Queanbeyan River at Queens Bridge and Molonglo River at Oaks Estate.</p>\n<p>Some further rainfall is possible during Sunday, and higher levels may occur.</p>\n<h3>Queanbeyan River:</h3>\n<p class=\"sl\">Minor flooding is occurring along the Queanbeyan River.</p>\n<p>The Queanbeyan River at Queens Bridge may peak near 5.00 metres around 02:00 pm Sunday, with minor flooding.</p>\n<h3>Molonglo River:</h3>\n<p class=\"sl\">Minor flooding is occurring along the Molonglo River.</p>\n<p>The Molonglo River at Oaks Estate may peak near 5.50 metres around midday Sunday, with minor flooding.</p>\n<h3>Flood Safety Advice:</h3>\n<p>In life threatening emergencies, call 000 (triple zero) immediately. If you require rescue, assistance to evacuate or other emergency help, ring NSW SES on 132 500.</p>\n<ul>\n<li>* Avoid drowning. Stay out of rising water, seek refuge in the highest available place.</li>\n<li>* Prevent damage to your vehicle. Move it under cover, away from areas likely to flood.</li>\n<li>* Avoid being swept away. Stay out of fast-flowing creeks and storm drains.</li>\n<li>* Never drive, ride or walk through flood water. Flood water can be deceptive and dangerous.</li>\n</ul>\n<p>For more emergency information, advice, and access to the latest river heights and rainfall observations and forecasts:</p>\n<p>* NSW SES: <a href=\"http://www.ses.nsw.gov.au\">www.ses.nsw.gov.au</a> </p>\n<p>* ACT SES: <a href=\"http://www.esa.act.gov.au/actses/\">www.esa.act.gov.au/actses/</a> </p>\n<p>* RMS Live Traffic: <a href=\"http://www.livetraffic.com\">www.livetraffic.com</a> </p>\n<p>* Latest River Heights and Rainfall Observations: <a href=\"http://www.bom.gov.au/nsw/flood/southwest.shtml\">www.bom.gov.au/nsw/flood/southwest.shtml</a> </p>\n<p>* Latest NSW Warnings: <a href=\"http://www.bom.gov.au/nsw/warnings/\">www.bom.gov.au/nsw/warnings/</a> </p>\n<p>* Rainfall Forecasts: <a href=\"http://www.bom.gov.au/australia/meteye/\">www.bom.gov.au/australia/meteye/</a> </p>\n<p>* BOM NSW Twitter: <a href=\"http://www.twitter.com/BOM_NSW\">www.twitter.com/BOM_NSW</a> </p>\n<p>* BOM ACT Twitter: <a href=\"http://www.twitter.com/BOM_ACT\">www.twitter.com/BOM_ACT</a> </p>\n<h3>Next Issue:</h3>\n<p>The next warning will be issued by 12:00 pm EDT on Monday 10 October 2022.</p>\n<h3>Latest River Heights:</h3>\n<table summary=\"This table contains recent observations of River Heights. There are four columns, the first gives the location of the river gauge, the second gives the river height, the third gives the current tendency of the river level and the fourth gives the time and date of the observation.\">\n<thead>\n<tr>\n<th>Location</th>\n<th>Height of River (m) </th>\n<th>Tendency</th>\n<th>Date/Time of Observation</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td align=\"left\" scope=\"row\">Queanbeyan River at Tinderry</td>\n<td align=\"left\" scope=\"row\">2.86</td>\n<td align=\"left\" scope=\"row\">Falling</td>\n<td align=\"left\" scope=\"row\">10:56 AM SUN 09/10/22</td>\n</tr>\n<tr>\n<td align=\"left\" scope=\"row\">Queanbeyan River at Wickerslack</td>\n<td align=\"left\" scope=\"row\">3.02</td>\n<td align=\"left\" scope=\"row\">Rising</td>\n<td align=\"left\" scope=\"row\">06:53 AM SUN 09/10/22</td>\n</tr>\n<tr>\n<td align=\"left\" scope=\"row\">Queanbeyan River at Queens Bridge</td>\n<td align=\"left\" scope=\"row\">4.55</td>\n<td align=\"left\" scope=\"row\">Steady</td>\n<td align=\"left\" scope=\"row\">10:15 AM SUN 09/10/22</td>\n</tr>\n<tr>\n<td align=\"left\" scope=\"row\">Molonglo River at Burbong</td>\n<td align=\"left\" scope=\"row\">1.99</td>\n<td align=\"left\" scope=\"row\">Rising</td>\n<td align=\"left\" scope=\"row\">07:44 AM SUN 09/10/22</td>\n</tr>\n</tbody>\n</table>\n<p>This advice is also available by dialling 1300 659 210. Warning, rainfall and river information are available at <a href=\"http://www.bom.gov.au/nsw/flood\">www.bom.gov.au/nsw/flood</a>. The latest weather forecast is available at <a href=\"http://www.bom.gov.au/nsw/forecasts\">www.bom.gov.au/nsw/forecasts</a>. </p>\n</div>\n",
-    "issue_time": "2022-10-09T00:00:41Z",
-    "expiry_time": "2022-10-12T00:00:41Z",
-    "phase": "renewal"
-  }
-}
-```
-
-The warning data is not well understood at present. Below is a list of observed values for fields that have a defined set of values.
-
-### type
-- flood_watch
-- flood_warning
-- sheep_graziers_warning
-- severe_thunderstorm_warning
-- severe_weather_warning
-- marine_wind_warning
-- hazardous_surf_warning
-- heatwave_warning
-
-### warning_group_type
-- major
-- minor
-
-### phase
-- new
-- update
-- renewal
-- downgrade
-- updgrade
-- final
-- cancelled
-
-### message
-contains a block of html with the outermost block being <div class="product">

--- a/custom_components/bureau_of_meteorology/PyBoM/collector.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/collector.py
@@ -1,18 +1,24 @@
-"""BOM data 'collector' that downloads the observation data."""
-import aiohttp
-import asyncio
-import datetime
-import time
 import logging
+import math
+import time
+import datetime
+import asyncio
+
+import aiohttp
 
 from homeassistant.util import Throttle
 
 from .const import (
-    MAP_MDI_ICON, URL_BASE, URL_DAILY,
-    URL_HOURLY, URL_OBSERVATIONS, URL_WARNINGS
+    MAP_MDI_ICON,
+    URL_BASE,
+    URL_DAILY,
+    URL_HOURLY,
+    URL_OBSERVATIONS,
+    URL_WARNINGS,
 )
 from .helpers import (
-    flatten_dict, geohash_encode,
+    flatten_dict,
+    geohash_encode,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,18 +28,97 @@ MAX_RETRIES = 3
 RETRY_DELAY_BASE = 2  # seconds
 MAX_CACHE_AGE = 86400  # 24 hours in seconds
 
+PLACE_DETAILS_URL = "https://api.bom.gov.au/apikey/v1/locations/places/details/place/"
+PLACE_AUTOCOMPLETE_FILTER = (
+    "nearby_type:bom_stn,elevation:300,capability:SENSOR_TEMPERATURE_DB,"
+    "match_coastal_status:true"
+)
+PLACE_FORECAST_DAILY_URL = "https://api.bom.gov.au/apikey/v1/forecasts/daily/{x}/{y}"
+PLACE_FORECAST_HOURLY_URL = "https://api.bom.gov.au/apikey/v1/forecasts/1hourly/{x}/{y}"
+PLACE_FORECAST_3HOURLY_URL = (
+    "https://api.bom.gov.au/apikey/v1/forecasts/3hourly/{x}/{y}"
+)
+PLACE_FORECAST_ASTRO_URL = (
+    "https://api.bom.gov.au/apikey/v1/forecasts/astro/{lon}/{lat}"
+)
+PLACE_FORECAST_TEXT_URL = "https://api.bom.gov.au/apikey/v1/forecasts/texts"
+PLACE_OBSERVATIONS_URL = "https://api.bom.gov.au/apikey/v1/observations/latest/{station_id}/atm/surf_air?include_qc_results=false"
+PLACE_WARNINGS_URL = "https://api.bom.gov.au/apikey/v1/warnings/list?area_type=coordinate&area_code={lon},{lat}"
+
+ICON_CODE_MAP = {
+    1: "sunny",
+    2: "clear",
+    3: "partly_cloudy",
+    4: "cloudy",
+    6: "haze",
+    8: "light_showers",
+    9: "windy",
+    10: "fog",
+    11: "showers",
+    12: "rain",
+    13: "dust",
+    14: "frost",
+    15: "snow",
+    16: "storms",
+    17: "light_showers",
+}
+
+COMPASS_DIRECTIONS = [
+    "N",
+    "NNE",
+    "NE",
+    "ENE",
+    "E",
+    "ESE",
+    "SE",
+    "SSE",
+    "S",
+    "SSW",
+    "SW",
+    "WSW",
+    "W",
+    "WNW",
+    "NW",
+    "NNW",
+]
+
+
 class Collector:
     """Collector for PyBoM."""
 
-    def __init__(self, latitude, longitude):
+    def __init__(
+        self,
+        latitude,
+        longitude,
+        forecast_source_geohash=None,
+        observation_source_geohash=None,
+        place_id=None,
+    ):
         """Init collector."""
         self.locations_data = None
         self.observations_data = None
         self.daily_forecasts_data = None
         self.hourly_forecasts_data = None
         self.warnings_data = None
-        self.geohash7 = geohash_encode(latitude, longitude)
-        self.geohash6 = self.geohash7[:6]
+        self.place_id = place_id
+        self.latitude = latitude
+        self.longitude = longitude
+        # BoM API location endpoints use 7-character geohashes.
+        if forecast_source_geohash and len(forecast_source_geohash) >= 7:
+            self.forecast_geohash7 = forecast_source_geohash[:7]
+        else:
+            self.forecast_geohash7 = geohash_encode(latitude, longitude, precision=7)
+        self.forecast_geohash6 = self.forecast_geohash7[:6]
+
+        if observation_source_geohash and len(observation_source_geohash) >= 7:
+            self.observation_geohash7 = observation_source_geohash[:7]
+        else:
+            self.observation_geohash7 = self.forecast_geohash7
+        self.observation_geohash6 = self.observation_geohash7[:6]
+        self.selected_observations_geohash = None
+        self.selected_forecasts_geohash = None
+        self.selected_daily_forecasts_geohash = None
+        self.selected_hourly_forecasts_geohash = None
         # Cache storage with timestamps
         self._cache = {
             "locations": {"data": None, "timestamp": 0},
@@ -42,6 +127,463 @@ class Collector:
             "hourly_forecasts": {"data": None, "timestamp": 0},
             "warnings": {"data": None, "timestamp": 0},
         }
+
+    @staticmethod
+    def _uv_category_from_index(uv_index):
+        """Map numeric UV to BoM category string."""
+        if uv_index is None:
+            return None
+        if uv_index < 3:
+            return "low"
+        if uv_index < 6:
+            return "moderate"
+        if uv_index < 8:
+            return "high"
+        if uv_index < 11:
+            return "veryhigh"
+        return "extreme"
+
+    @staticmethod
+    def _wind_direction_from_degrees(direction):
+        """Return compass direction from degrees."""
+        if direction is None:
+            return None
+        index = int((float(direction) + 11.25) // 22.5) % 16
+        return COMPASS_DIRECTIONS[index]
+
+    @staticmethod
+    def _rain_range_from_precip(precipitation):
+        """Approximate BoM displayed rain range from percentile totals."""
+        if not precipitation:
+            return (None, None)
+
+        low = precipitation.get("exceeding_75percentchance_total_mm")
+        high = precipitation.get("exceeding_25percentchance_total_mm")
+        if low is None and high is None:
+            return (None, None)
+
+        low_value = None if low is None else max(0, math.floor(low))
+        high_value = None if high is None else max(0, round(high))
+        if high_value is None:
+            high_value = low_value
+        if low_value is None:
+            low_value = 0 if high_value == 0 else None
+        return (low_value, high_value)
+
+    @staticmethod
+    def _icon_descriptor_from_code(icon_code):
+        """Map numeric icon code to old descriptor strings."""
+        return ICON_CODE_MAP.get(icon_code, "cloudy")
+
+    def _map_place_to_locations_data(self, place_details):
+        """Convert place details payload to legacy locations structure."""
+        place = place_details["place"]
+        coordinate = place.get("coordinate", {})
+        state = place.get("state", {})
+        return {
+            "metadata": {
+                "response_timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            },
+            "data": {
+                "id": place.get("id"),
+                "name": place.get("name"),
+                "state": state.get("abbrev") if isinstance(state, dict) else state,
+                "timezone": place.get("timezone"),
+                "latitude": coordinate.get("latitude"),
+                "longitude": coordinate.get("longitude"),
+            },
+        }
+
+    @staticmethod
+    def _speed_mps_to_kmh(speed_mps):
+        """Convert m/s to km/h."""
+        if speed_mps is None:
+            return None
+        return round(speed_mps * 3.6)
+
+    @staticmethod
+    def _speed_mps_to_knots(speed_mps):
+        """Convert m/s to knots."""
+        if speed_mps is None:
+            return None
+        return round(speed_mps * 1.943844)
+
+    def _pick_text_detail(self, daily_text):
+        """Choose the richest available area text for a day."""
+        weather = daily_text.get("atm", {}).get("surf_air", {}).get("weather", {})
+        for key in (
+            "locality_text",
+            "metropolitan_text",
+            "public_district_text",
+            "coast_text",
+            "region_text",
+            "precis_text",
+        ):
+            if weather.get(key):
+                return weather.get(key)
+        return None
+
+    @staticmethod
+    def _pick_precis_text(daily_text):
+        """Pick concise precis text for a day."""
+        return (
+            daily_text.get("atm", {})
+            .get("surf_air", {})
+            .get("weather", {})
+            .get("precis_text")
+        )
+
+    async def _get_place_details(self, session):
+        """Fetch canonical place details from the newer BoM API."""
+        if not self.place_id:
+            return None
+
+        url = f"{PLACE_DETAILS_URL}{self.place_id}"
+        params = {
+            "filter": PLACE_AUTOCOMPLETE_FILTER,
+            "radius": 100000,
+            "nearby_limit": 10,
+        }
+        return await self._fetch_with_retry(
+            session,
+            f"{url}?filter={params['filter']}&radius={params['radius']}&nearby_limit={params['nearby_limit']}",
+            "locations",
+        )
+
+    def _should_use_place_observations(self):
+        """Use canonical place observations only when observation source wasn't overridden."""
+        return self.observation_geohash6 == self.forecast_geohash6
+
+    def _map_place_to_observations_data(self, place_details, observation_payload):
+        """Convert place observation payload to legacy observation structure."""
+        place = place_details.get("place", {})
+        nearest = (place.get("location_hierarchy", {}) or {}).get("nearest", {})
+        observation = observation_payload.get("obs", {})
+        station = observation_payload.get("stn", {})
+        identity = station.get("identity", {})
+        wind = observation.get("wind", {})
+        temp = observation.get("temp", {})
+        precip = observation.get("precip", {})
+
+        return {
+            "metadata": {
+                "response_timestamp": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                ),
+                "issue_time": observation.get("datetime_utc"),
+                "observation_time": observation.get("datetime_utc"),
+            },
+            "data": {
+                "temp": None
+                if temp.get("dry_bulb_1min_cel") is None
+                else round(temp.get("dry_bulb_1min_cel")),
+                "temp_feels_like": None
+                if temp.get("apparent_1min_cel") is None
+                else round(temp.get("apparent_1min_cel"), 1),
+                "wind": {
+                    "speed_kilometre": self._speed_mps_to_kmh(
+                        wind.get("speed_10m_mps") or wind.get("speed_10m_avg_mps")
+                    ),
+                    "speed_knot": self._speed_mps_to_knots(
+                        wind.get("speed_10m_mps") or wind.get("speed_10m_avg_mps")
+                    ),
+                    "direction": wind.get("dirn_10m_ord")
+                    or self._wind_direction_from_degrees(wind.get("dirn_10m_deg_t")),
+                },
+                "gust": {
+                    "speed_kilometre": self._speed_mps_to_kmh(
+                        wind.get("gust_speed_10m_mps")
+                        or wind.get("gust_speed_10m_max_mps")
+                    ),
+                    "speed_knot": self._speed_mps_to_knots(
+                        wind.get("gust_speed_10m_mps")
+                        or wind.get("gust_speed_10m_max_mps")
+                    ),
+                },
+                "max_temp": {
+                    "time": temp.get("dry_bulb_max_time_utc"),
+                    "value": temp.get("dry_bulb_max_cel"),
+                },
+                "min_temp": {
+                    "time": temp.get("dry_bulb_min_time_utc"),
+                    "value": temp.get("dry_bulb_min_cel"),
+                },
+                "rain_since_9am": precip.get("since_0900lct_total_mm"),
+                "humidity": temp.get("rel_hum_percent"),
+                "station": {
+                    "bom_id": str(identity.get("bom_stn_num") or nearest.get("id")),
+                    "name": identity.get("bom_stn_name") or nearest.get("name"),
+                    "distance": nearest.get("distance"),
+                },
+            },
+        }
+
+    async def _async_update_place_observations(self, session, place_details):
+        """Fetch observations from the newer place/station API."""
+        nearest = (
+            place_details.get("place", {}).get("location_hierarchy", {}) or {}
+        ).get("nearest", {})
+        station_id = nearest.get("id")
+        if not station_id:
+            return False
+
+        data = await self._fetch_with_retry(
+            session,
+            PLACE_OBSERVATIONS_URL.format(station_id=station_id),
+            "observations",
+        )
+        if not data or not data.get("obs"):
+            return False
+
+        self.observations_data = self._map_place_to_observations_data(
+            place_details,
+            data,
+        )
+        self.selected_observations_geohash = self.observation_geohash6
+        return True
+
+    async def _async_update_place_warnings(self, session, place_details):
+        """Fetch warnings from newer coordinate-based warnings API."""
+        coordinate = place_details.get("place", {}).get("coordinate", {})
+        latitude = coordinate.get("latitude")
+        longitude = coordinate.get("longitude")
+        if latitude is None or longitude is None:
+            return False
+
+        data = await self._fetch_with_retry(
+            session,
+            PLACE_WARNINGS_URL.format(lon=longitude, lat=latitude),
+            "warnings",
+        )
+        if data is None or "warnings" not in data:
+            return False
+
+        self.warnings_data = {
+            "metadata": {
+                "response_timestamp": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                ),
+            },
+            "data": data.get("warnings", []),
+        }
+        return True
+
+    async def _async_update_place_forecasts(self, session, place_details):
+        """Fetch daily/hourly forecast data from the newer place/grid APIs."""
+        place = place_details["place"]
+        forecast_grid = place.get("gridcells", {}).get("forecast", {})
+        grid_x = forecast_grid.get("x")
+        grid_y = forecast_grid.get("y")
+        timezone = place.get("timezone")
+        coordinate = place.get("coordinate", {})
+        latitude = coordinate.get("latitude")
+        longitude = coordinate.get("longitude")
+
+        if grid_x is None or grid_y is None or timezone is None:
+            return
+
+        daily_data = await self._fetch_with_retry(
+            session,
+            PLACE_FORECAST_DAILY_URL.format(x=grid_x, y=grid_y)
+            + f"?timezone={timezone}",
+            "daily_forecasts",
+        )
+        hourly_data = await self._fetch_with_retry(
+            session,
+            PLACE_FORECAST_HOURLY_URL.format(x=grid_x, y=grid_y)
+            + f"?timezone={timezone}",
+            "hourly_forecasts",
+        )
+        three_hourly_data = await self._fetch_with_retry(
+            session,
+            PLACE_FORECAST_3HOURLY_URL.format(x=grid_x, y=grid_y)
+            + f"?timezone={timezone}",
+            "hourly_forecasts",
+        )
+        astro_data = await self._fetch_with_retry(
+            session,
+            PLACE_FORECAST_ASTRO_URL.format(lon=longitude, lat=latitude),
+            "daily_forecasts",
+        )
+
+        text_aac = "SA_ME001"
+        hier = place.get("location_hierarchy", {})
+        metros = hier.get("metropolitan", [])
+        if metros and metros[0].get("aac"):
+            text_aac = metros[0]["aac"]
+        precis_aac = (hier.get("precis_fcst", {}) or {}).get("aac")
+        text_data = await self._fetch_with_retry(
+            session,
+            PLACE_FORECAST_TEXT_URL + f"?aac={text_aac}&timezone={timezone}",
+            "daily_forecasts",
+        )
+        precis_text_data = None
+        if precis_aac:
+            precis_text_data = await self._fetch_with_retry(
+                session,
+                PLACE_FORECAST_TEXT_URL + f"?aac={precis_aac}&timezone={timezone}",
+                "daily_forecasts",
+            )
+
+        if daily_data and daily_data.get("fcst", {}).get("daily"):
+            astro_by_date = {
+                item.get("date_utc"): item.get("astro", {})
+                for item in (astro_data or {}).get("fcst", {}).get("daily", [])
+            }
+            text_by_date = {
+                item.get("date_utc"): item
+                for item in (text_data or {}).get("fcst", {}).get("daily", [])
+            }
+            precis_by_date = {
+                item.get("date_utc"): item
+                for item in (precis_text_data or {}).get("fcst", {}).get("daily", [])
+            }
+
+            converted_daily = []
+            for index, item in enumerate(daily_data["fcst"]["daily"]):
+                surf_air = item.get("atm", {}).get("surf_air", {})
+                precip = surf_air.get("precip", {})
+                radiation = surf_air.get("radiation", {})
+                astro = astro_by_date.get(item.get("date_utc"), {})
+                text_item = text_by_date.get(item.get("date_utc"), {})
+                precis_item = precis_by_date.get(item.get("date_utc"), {})
+                icon_descriptor = self._icon_descriptor_from_code(
+                    surf_air.get("weather", {}).get("icon_code")
+                )
+                uv_max = radiation.get("uv_clear_sky_max_code")
+                rain_min, rain_max = self._rain_range_from_precip(precip)
+
+                converted = {
+                    "date": item.get("date_utc"),
+                    "temp_max": None
+                    if surf_air.get("temp_max_cel") is None
+                    else round(surf_air.get("temp_max_cel")),
+                    "temp_min": None
+                    if surf_air.get("temp_min_cel") is None
+                    else round(surf_air.get("temp_min_cel")),
+                    "icon_descriptor": icon_descriptor,
+                    "mdi_icon": MAP_MDI_ICON[icon_descriptor],
+                    "short_text": self._pick_precis_text(precis_item)
+                    or self._pick_precis_text(text_item),
+                    "extended_text": self._pick_text_detail(text_item),
+                    "uv_category": self._uv_category_from_index(uv_max),
+                    "uv_max_index": None if uv_max is None else round(uv_max),
+                    "uv_start_time": radiation.get("uv_period_start"),
+                    "uv_end_time": radiation.get("uv_period_end"),
+                    "rain_amount_min": rain_min,
+                    "rain_amount_max": rain_max,
+                    "rain_amount_range": rain_min
+                    if rain_min == rain_max
+                    else f"{rain_min}–{rain_max}",
+                    "rain_chance": None
+                    if precip.get("any_probability_percent") is None
+                    else round(precip.get("any_probability_percent")),
+                    "fire_danger": None,
+                    "fire_danger_category": {
+                        "text": None,
+                        "default_colour": None,
+                        "dark_mode_colour": None,
+                    },
+                    "astronomical_sunrise_time": astro.get("sunrise_utc"),
+                    "astronomical_sunset_time": astro.get("sunset_utc"),
+                    "now_now_label": None,
+                    "now_temp_now": None,
+                    "now_later_label": None,
+                    "now_temp_later": None,
+                }
+                if index == 0:
+                    converted["now_now_label"] = "Max"
+                    converted["now_temp_now"] = converted["temp_max"]
+                    converted["now_later_label"] = "Overnight Min"
+                    converted["now_temp_later"] = converted["temp_min"]
+                converted_daily.append(converted)
+
+            self.daily_forecasts_data = {
+                "metadata": {
+                    "response_timestamp": (daily_data.get("meta") or {}).get(
+                        "issue_time_utc"
+                    ),
+                    "issue_time": (daily_data.get("meta") or {}).get("issue_time_utc"),
+                },
+                "data": converted_daily,
+            }
+            self.selected_forecasts_geohash = self.forecast_geohash7
+            self.selected_daily_forecasts_geohash = self.forecast_geohash7
+
+        if hourly_data and hourly_data.get("fcst"):
+            three_hourly_buckets = []
+            for day in (three_hourly_data or {}).get("fcst", []):
+                for bucket in day.get("3hourly", []):
+                    three_hourly_buckets.append(bucket)
+
+            converted_hourly = []
+            for day in hourly_data.get("fcst", []):
+                for item in day.get("1hourly", []):
+                    surf_air = item.get("atm", {}).get("surf_air", {})
+                    time_utc = item.get("time_utc")
+                    bucket = next(
+                        (
+                            candidate
+                            for candidate in three_hourly_buckets
+                            if candidate.get("start_time_utc") <= time_utc
+                            and candidate.get("end_time_utc") > time_utc
+                        ),
+                        None,
+                    )
+                    bucket_air = (bucket or {}).get("atm", {}).get("surf_air", {})
+                    bucket_precip = bucket_air.get("precip", {})
+                    rain_min, rain_max = self._rain_range_from_precip(bucket_precip)
+                    icon_descriptor = self._icon_descriptor_from_code(
+                        bucket_air.get("weather", {}).get("icon_code")
+                    )
+                    wind = surf_air.get("wind", {})
+                    converted_hourly.append(
+                        {
+                            "time": time_utc,
+                            "temp": None
+                            if surf_air.get("temp_cel") is None
+                            else round(surf_air.get("temp_cel"), 1),
+                            "icon_descriptor": icon_descriptor,
+                            "mdi_icon": MAP_MDI_ICON[icon_descriptor],
+                            "rain_amount_min": rain_min,
+                            "rain_amount_max": rain_max,
+                            "rain_amount_range": rain_min
+                            if rain_min == rain_max
+                            else f"{rain_min} to {rain_max}",
+                            "rain_chance": None
+                            if bucket_precip.get("precip_any_probability_percent")
+                            is None
+                            else round(
+                                bucket_precip.get("precip_any_probability_percent")
+                            ),
+                            "wind_direction": self._wind_direction_from_degrees(
+                                wind.get("dirn_10m_deg_t")
+                            ),
+                            "wind_speed_kilometre": None
+                            if wind.get("speed_10m_avg_mps") is None
+                            else round(wind.get("speed_10m_avg_mps") * 3.6),
+                            "wind_gust_speed_kilometre": None
+                            if wind.get("gust_speed_10m_max_mps") is None
+                            else round(wind.get("gust_speed_10m_max_mps") * 3.6),
+                            "relative_humidity": surf_air.get("hum_relative_percent"),
+                            "uv": surf_air.get("radiation", {}).get(
+                                "uv_clear_sky_code"
+                            ),
+                            "is_night": False,
+                        }
+                    )
+
+            self.hourly_forecasts_data = {
+                "metadata": {
+                    "response_timestamp": (hourly_data.get("meta") or {}).get(
+                        "issue_time_utc"
+                    ),
+                    "issue_time": (hourly_data.get("meta") or {}).get("issue_time_utc"),
+                },
+                "data": converted_hourly,
+            }
+            self.selected_forecasts_geohash = self.forecast_geohash7
+            self.selected_hourly_forecasts_geohash = self.forecast_geohash7
 
     async def _fetch_with_retry(self, session, url, cache_key):
         """Fetch data with retry mechanism and store in cache if successful."""
@@ -54,14 +596,21 @@ class Collector:
                         self._cache[cache_key]["data"] = data
                         self._cache[cache_key]["timestamp"] = time.time()
                         return data
+                    if 400 <= response.status < 500 and response.status != 429:
+                        _LOGGER.debug(
+                            "BoM API returned %s for %s; skipping retries for this geohash",
+                            response.status,
+                            url,
+                        )
+                        return None
                     else:
                         _LOGGER.warning(
                             f"Error requesting API data from {url}: {response.status}"
                         )
             except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-                wait_time = RETRY_DELAY_BASE ** attempt
+                wait_time = RETRY_DELAY_BASE**attempt
                 _LOGGER.warning(
-                    f"Attempt {attempt+1}/{MAX_RETRIES} failed: {err}. "
+                    f"Attempt {attempt + 1}/{MAX_RETRIES} failed: {err}. "
                     f"Retrying in {wait_time} seconds..."
                 )
                 if attempt < MAX_RETRIES - 1:
@@ -76,21 +625,27 @@ class Collector:
                     if cached is not None:
                         cache_age = time.time() - self._cache[cache_key]["timestamp"]
                         _LOGGER.info(
-                            f"Returning cached {cache_key} data from {int(cache_age/60)} minutes ago"
+                            f"Returning cached {cache_key} data from {int(cache_age / 60)} minutes ago"
                         )
                         return cached
                     else:
                         _LOGGER.error(f"No cached {cache_key} data available")
                         return None
         return None
-    
+
     async def get_locations_data(self):
         """Get JSON location name from BOM API endpoint."""
         headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
         try:
             async with aiohttp.ClientSession(headers=headers) as session:
+                if self.place_id:
+                    data = await self._get_place_details(session)
+                    if data and data.get("place"):
+                        self.locations_data = self._map_place_to_locations_data(data)
+                        return
+
                 data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash7, "locations"
+                    session, URL_BASE + self.forecast_geohash7, "locations"
                 )
                 if data:
                     self.locations_data = data
@@ -102,7 +657,7 @@ class Collector:
         if not self.daily_forecasts_data or "data" not in self.daily_forecasts_data:
             _LOGGER.warning("No daily forecast data to format")
             return
-            
+
         days = len(self.daily_forecasts_data["data"])
         for day in range(0, days):
             d = self.daily_forecasts_data["data"][day]
@@ -130,15 +685,16 @@ class Collector:
                 d["rain_amount_max"] = d["rain_amount_min"]
                 d["rain_amount_range"] = d["rain_amount_min"]
             else:
-                d["rain_amount_range"] = f"{d['rain_amount_min']}–{d['rain_amount_max']}"
-
+                d["rain_amount_range"] = (
+                    f"{d['rain_amount_min']}–{d['rain_amount_max']}"
+                )
 
     async def format_hourly_forecast_data(self):
         """Format forecast data."""
         if not self.hourly_forecasts_data or "data" not in self.hourly_forecasts_data:
             _LOGGER.warning("No hourly forecast data to format")
             return
-            
+
         hours = len(self.hourly_forecasts_data["data"])
         for hour in range(0, hours):
             d = self.hourly_forecasts_data["data"][hour]
@@ -163,64 +719,162 @@ class Collector:
                 d["rain_amount_max"] = d["rain_amount_min"]
                 d["rain_amount_range"] = d["rain_amount_min"]
             else:
-                d["rain_amount_range"] = f"{d['rain_amount_min']} to {d['rain_amount_max']}"
+                d["rain_amount_range"] = (
+                    f"{d['rain_amount_min']} to {d['rain_amount_max']}"
+                )
 
     @Throttle(datetime.timedelta(minutes=5))
     async def async_update(self):
         """Refresh the data on the collector object."""
         headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
-        
+
         try:
             async with aiohttp.ClientSession(headers=headers) as session:
                 # Get location data if not already available
                 if self.locations_data is None:
-                    data = await self._fetch_with_retry(
-                        session, URL_BASE + self.geohash7, "locations"
-                    )
-                    if data:
-                        self.locations_data = data
-                
-                # Get observations data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash6 + URL_OBSERVATIONS, "observations"
-                )
-                if data:
-                    self.observations_data = data
-                    if self.observations_data["data"]["wind"] is not None:
+                    if self.place_id:
+                        place_details = await self._get_place_details(session)
+                        if place_details and place_details.get("place"):
+                            self.locations_data = self._map_place_to_locations_data(
+                                place_details
+                            )
+                        else:
+                            place_details = None
+                    else:
+                        place_details = None
+
+                    if self.locations_data is None:
+                        data = await self._fetch_with_retry(
+                            session, URL_BASE + self.forecast_geohash7, "locations"
+                        )
+                        if data:
+                            self.locations_data = data
+                else:
+                    place_details = None
+
+                # Get observations data. Prefer place nearest station when the
+                # observation source hasn't been explicitly overridden.
+                place_observations_loaded = False
+                if self.place_id and self._should_use_place_observations():
+                    if place_details is None:
+                        place_details = await self._get_place_details(session)
+                    if place_details and place_details.get("place"):
+                        place_observations_loaded = (
+                            await self._async_update_place_observations(
+                                session,
+                                place_details,
+                            )
+                        )
+
+                if not place_observations_loaded:
+                    observations_data = None
+                    selected_obs_geohash = None
+                    for geohash in dict.fromkeys(
+                        [self.observation_geohash7, self.observation_geohash6]
+                    ):
+                        data = await self._fetch_with_retry(
+                            session,
+                            URL_BASE + geohash + URL_OBSERVATIONS,
+                            "observations",
+                        )
+                        if data and data.get("data") is not None:
+                            if data["data"].get("temp") is not None:
+                                observations_data = data
+                                selected_obs_geohash = geohash
+                                break
+                            if observations_data is None:
+                                observations_data = data
+                                selected_obs_geohash = geohash
+
+                    if observations_data:
+                        self.observations_data = observations_data
+                        self.selected_observations_geohash = selected_obs_geohash
+
+                if self.observations_data:
+                    if self.observations_data["data"].get("wind") is not None:
                         flatten_dict(["wind"], self.observations_data["data"])
                     else:
                         self.observations_data["data"]["wind_direction"] = "unavailable"
-                        self.observations_data["data"]["wind_speed_kilometre"] = "unavailable"
-                        self.observations_data["data"]["wind_speed_knot"] = "unavailable"
-                    if self.observations_data["data"]["gust"] is not None:
+                        self.observations_data["data"]["wind_speed_kilometre"] = (
+                            "unavailable"
+                        )
+                        self.observations_data["data"]["wind_speed_knot"] = (
+                            "unavailable"
+                        )
+                    if self.observations_data["data"].get("gust") is not None:
                         flatten_dict(["gust"], self.observations_data["data"])
                     else:
-                        self.observations_data["data"]["gust_speed_kilometre"] = "unavailable"
-                        self.observations_data["data"]["gust_speed_knot"] = "unavailable"
+                        self.observations_data["data"]["gust_speed_kilometre"] = (
+                            "unavailable"
+                        )
+                        self.observations_data["data"]["gust_speed_knot"] = (
+                            "unavailable"
+                        )
 
-                # Get daily forecast data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash6 + URL_DAILY, "daily_forecasts"
-                )
-                if data:
-                    self.daily_forecasts_data = data
-                    await self.format_daily_forecast_data()
+                if self.place_id:
+                    if place_details is None:
+                        place_details = await self._get_place_details(session)
+                    if place_details and place_details.get("place"):
+                        await self._async_update_place_forecasts(session, place_details)
 
-                # Get hourly forecast data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash6 + URL_HOURLY, "hourly_forecasts"
-                )
-                if data:
-                    self.hourly_forecasts_data = data
-                    await self.format_hourly_forecast_data()
+                if self.daily_forecasts_data is None:
+                    # Get daily forecast data
+                    for geohash in dict.fromkeys(
+                        [self.forecast_geohash7, self.forecast_geohash6]
+                    ):
+                        data = await self._fetch_with_retry(
+                            session,
+                            URL_BASE + geohash + URL_DAILY,
+                            "daily_forecasts",
+                        )
+                        if data and data.get("data") is not None:
+                            self.daily_forecasts_data = data
+                            self.selected_forecasts_geohash = geohash
+                            self.selected_daily_forecasts_geohash = geohash
+                            await self.format_daily_forecast_data()
+                            break
 
-                # Get warnings data
-                data = await self._fetch_with_retry(
-                    session, URL_BASE + self.geohash6 + URL_WARNINGS, "warnings"
-                )
-                if data:
-                    self.warnings_data = data
-                    
+                if self.hourly_forecasts_data is None:
+                    # Get hourly forecast data
+                    for geohash in dict.fromkeys(
+                        [self.forecast_geohash7, self.forecast_geohash6]
+                    ):
+                        data = await self._fetch_with_retry(
+                            session,
+                            URL_BASE + geohash + URL_HOURLY,
+                            "hourly_forecasts",
+                        )
+                        if data and data.get("data") is not None:
+                            self.hourly_forecasts_data = data
+                            self.selected_forecasts_geohash = geohash
+                            self.selected_hourly_forecasts_geohash = geohash
+                            await self.format_hourly_forecast_data()
+                            break
+
+                warnings_loaded = False
+                if self.place_id:
+                    if place_details is None:
+                        place_details = await self._get_place_details(session)
+                    if place_details and place_details.get("place"):
+                        warnings_loaded = await self._async_update_place_warnings(
+                            session,
+                            place_details,
+                        )
+
+                if not warnings_loaded:
+                    # Get warnings data
+                    for geohash in dict.fromkeys(
+                        [self.forecast_geohash7, self.forecast_geohash6]
+                    ):
+                        data = await self._fetch_with_retry(
+                            session,
+                            URL_BASE + geohash + URL_WARNINGS,
+                            "warnings",
+                        )
+                        if data and data.get("data") is not None:
+                            self.warnings_data = data
+                            break
+
         except Exception as err:
             _LOGGER.error(f"Unexpected error during async_update: {err}")
             # Even if we have an unexpected error, we still have our cached data

--- a/custom_components/bureau_of_meteorology/PyBoM/helpers.py
+++ b/custom_components/bureau_of_meteorology/PyBoM/helpers.py
@@ -1,7 +1,5 @@
 """Helpers functions for PyBom."""
-import asyncio
-import logging
-import socket
+
 
 def flatten_dict(keys, dict):
     for key in keys:
@@ -11,8 +9,9 @@ def flatten_dict(keys, dict):
                 dict[key + "_" + inner_key] = value
     return dict
 
+
 def geohash_encode(latitude, longitude, precision=6):
-    base32 = '0123456789bcdefghjkmnpqrstuvwxyz'
+    base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
     lat_interval = (-90.0, 90.0)
     lon_interval = (-180.0, 180.0)
     geohash = []
@@ -42,4 +41,4 @@ def geohash_encode(latitude, longitude, precision=6):
             geohash += base32[ch]
             bit = 0
             ch = 0
-    return ''.join(geohash)
+    return "".join(geohash)

--- a/custom_components/bureau_of_meteorology/__init__.py
+++ b/custom_components/bureau_of_meteorology/__init__.py
@@ -1,5 +1,5 @@
 """The BOM integration."""
-import asyncio
+
 import datetime
 import logging
 
@@ -15,13 +15,17 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     COLLECTOR,
+    CONF_FORECAST_LOCATION_GEOHASH,
     CONF_FORECASTS_BASENAME,
     CONF_FORECASTS_CREATE,
     CONF_FORECASTS_DAYS,
     CONF_FORECASTS_MONITORED,
+    CONF_LOCATION_GEOHASH,
+    CONF_OBSERVATION_LOCATION_GEOHASH,
     CONF_OBSERVATIONS_BASENAME,
     CONF_OBSERVATIONS_CREATE,
     CONF_OBSERVATIONS_MONITORED,
+    CONF_PLACE_ID,
     CONF_WARNINGS_BASENAME,
     CONF_WARNINGS_CREATE,
     CONF_WEATHER_NAME,
@@ -50,7 +54,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
-
         new = {**config_entry.data}
         if CONF_FORECASTS_BASENAME in new:
             new[CONF_WEATHER_NAME] = config_entry.data[CONF_FORECASTS_BASENAME]
@@ -64,14 +67,45 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up BOM from a config entry."""
-    collector = Collector(entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE])
+    latitude = entry.options.get(CONF_LATITUDE, entry.data[CONF_LATITUDE])
+    longitude = entry.options.get(CONF_LONGITUDE, entry.data[CONF_LONGITUDE])
+    legacy_source_geohash = entry.options.get(
+        CONF_LOCATION_GEOHASH,
+        entry.data.get(CONF_LOCATION_GEOHASH),
+    )
+    forecast_source_geohash = entry.options.get(
+        CONF_FORECAST_LOCATION_GEOHASH,
+        entry.data.get(CONF_FORECAST_LOCATION_GEOHASH, legacy_source_geohash),
+    )
+    observation_source_geohash = entry.options.get(
+        CONF_OBSERVATION_LOCATION_GEOHASH,
+        entry.data.get(
+            CONF_OBSERVATION_LOCATION_GEOHASH,
+            forecast_source_geohash,
+        ),
+    )
+    place_id = entry.options.get(
+        CONF_PLACE_ID,
+        entry.data.get(CONF_PLACE_ID),
+    )
+    collector = Collector(
+        latitude,
+        longitude,
+        forecast_source_geohash,
+        observation_source_geohash,
+        place_id,
+    )
 
     try:
         await collector.async_update()
     except ClientConnectorError as ex:
         raise ConfigEntryNotReady from ex
 
-    coordinator = BomDataUpdateCoordinator(hass=hass, collector=collector)
+    coordinator = BomDataUpdateCoordinator(
+        hass=hass,
+        collector=collector,
+        entry_id=entry.entry_id,
+    )
     await coordinator.async_refresh()
 
     hass_data = hass.data.setdefault(DOMAIN, {})
@@ -104,7 +138,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # if observations are enabled, keep the configured observation sensors
     if entry.options.get(CONF_OBSERVATIONS_CREATE) is True:
-        for observation in entry.options.get(CONF_OBSERVATIONS_MONITORED):
+        for observation in entry.options.get(CONF_OBSERVATIONS_MONITORED, []):
             entities_to_keep.append(
                 f"sensor.{str(entry.options.get(CONF_OBSERVATIONS_BASENAME)).lower()}_{str(observation).lower()}"
             )
@@ -112,7 +146,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     # if forecasts are enabled, keep the configured forecast sensors
     if entry.options.get(CONF_FORECASTS_CREATE) is True:
         for day in range(0, entry.options.get(CONF_FORECASTS_DAYS, 0) + 1):
-            for forecast in entry.options.get(CONF_FORECASTS_MONITORED):
+            for forecast in entry.options.get(CONF_FORECASTS_MONITORED, []):
                 if forecast in [
                     "now_now_label",
                     "now_temp_now",
@@ -162,9 +196,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 class BomDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for Bureau of Meteorology."""
 
-    def __init__(self, hass: HomeAssistant, collector: Collector) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        collector: Collector,
+        entry_id: str,
+    ) -> None:
         """Initialise the data update coordinator."""
         self.collector = collector
+        self.entry_id = entry_id
         super().__init__(
             hass=hass,
             logger=_LOGGER,
@@ -190,9 +230,7 @@ class BomDataUpdateCoordinator(DataUpdateCoordinator):
         """Remove devices with no entities."""
         entity_registry = er.async_get(self.hass)
         device_registry = dr.async_get(self.hass)
-        device_list = dr.async_entries_for_config_entry(
-            device_registry, self.config_entry.entry_id
-        )
+        device_list = dr.async_entries_for_config_entry(device_registry, self.entry_id)
 
         for device_entry in device_list:
             entities = er.async_entries_for_device(
@@ -202,5 +240,5 @@ class BomDataUpdateCoordinator(DataUpdateCoordinator):
             if not entities:
                 _LOGGER.debug("Removing orphaned device: %s", device_entry.name)
                 device_registry.async_update_device(
-                    device_entry.id, remove_config_entry_id=self.config_entry.entry_id
+                    device_entry.id, remove_config_entry_id=self.entry_id
                 )

--- a/custom_components/bureau_of_meteorology/config_flow.py
+++ b/custom_components/bureau_of_meteorology/config_flow.py
@@ -1,31 +1,278 @@
 """Config flow for BOM."""
+
+import math
 import logging
 
+import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 
 from .const import (
+    CONF_FORECAST_LOCATION_GEOHASH,
     CONF_FORECASTS_BASENAME,
     CONF_FORECASTS_CREATE,
     CONF_FORECASTS_DAYS,
     CONF_FORECASTS_MONITORED,
+    CONF_OBSERVATION_LOCATION_GEOHASH,
     CONF_OBSERVATIONS_BASENAME,
     CONF_OBSERVATIONS_CREATE,
     CONF_OBSERVATIONS_MONITORED,
+    CONF_PLACE_ID,
     CONF_WARNINGS_BASENAME,
     CONF_WARNINGS_CREATE,
     CONF_WEATHER_NAME,
     DOMAIN,
     OBSERVATION_SENSOR_TYPES,
     FORECAST_SENSOR_TYPES,
-    WARNING_SENSOR_TYPES,
 )
 from .PyBoM.collector import Collector
+from .PyBoM.helpers import geohash_encode
 
 _LOGGER = logging.getLogger(__name__)
+
+SEARCH_OFFSETS = (0.0, 0.02, -0.02)
+DEFAULT_TOP_LOCATION_CHOICES = 3
+PLACE_AUTOCOMPLETE_URL = (
+    "https://api.bom.gov.au/apikey/v1/locations/places/autocomplete"
+)
+WEATHER_BOM_LOCATION_URL = "https://api.weather.bom.gov.au/v1/locations/"
+
+
+def _distance_meters(lat_a, lon_a, lat_b, lon_b):
+    """Return approximate distance in meters using equirectangular projection."""
+    earth_radius = 6371000
+    pi_over_180 = math.pi / 180
+    x = (lon_b - lon_a) * pi_over_180 * math.cos((lat_a + lat_b) * pi_over_180 / 2)
+    y = (lat_b - lat_a) * pi_over_180
+    return (x * x + y * y) ** 0.5 * earth_radius
+
+
+def _collector_forecast_geohash7(collector: Collector | None) -> str:
+    """Return the collector forecast geohash or a safe fallback."""
+    if collector is None:
+        return ""
+    return collector.forecast_geohash7
+
+
+def _collector_location_name(collector: Collector | None) -> str:
+    """Return the collector location name or a safe fallback."""
+    if collector is None:
+        return "Location"
+    return ((collector.locations_data or {}).get("data") or {}).get("name", "Location")
+
+
+def _collector_observation_station_name(collector: Collector | None) -> str:
+    """Return the collector observation station name or a safe fallback."""
+    if collector is None:
+        return "Observation"
+    return (
+        ((collector.observations_data or {}).get("data") or {})
+        .get("station", {})
+        .get("name", "Observation")
+    )
+
+
+async def _get_top_location_choices(
+    latitude, longitude, limit=DEFAULT_TOP_LOCATION_CHOICES
+):
+    """Return the closest canonical BoM places for the given coordinates."""
+    headers = {"User-Agent": "MakeThisAPIOpenSource/1.0.0"}
+    by_geohash = {}
+
+    async with aiohttp.ClientSession(headers=headers) as session:
+        for lat_offset in SEARCH_OFFSETS:
+            for lon_offset in SEARCH_OFFSETS:
+                query_lat = latitude + lat_offset
+                query_lon = longitude + lon_offset
+                url = (
+                    "https://api.weather.bom.gov.au/v1/locations"
+                    f"?search={query_lat:.6f},{query_lon:.6f}"
+                )
+                try:
+                    async with session.get(url) as response:
+                        if response.status != 200:
+                            continue
+                        payload = await response.json()
+                except aiohttp.ClientError:
+                    continue
+
+                for location in payload.get("data", []):
+                    geohash = location.get("geohash")
+                    if geohash and geohash not in by_geohash:
+                        by_geohash[geohash] = location
+
+        detailed_locations = []
+        for geohash in by_geohash:
+            detail_url = f"https://api.weather.bom.gov.au/v1/locations/{geohash}"
+            try:
+                async with session.get(detail_url) as response:
+                    if response.status != 200:
+                        continue
+                    payload = await response.json()
+            except aiohttp.ClientError:
+                continue
+
+            location = payload.get("data")
+            if not location:
+                continue
+
+            lat = location.get("latitude")
+            lon = location.get("longitude")
+            if lat is None or lon is None:
+                continue
+
+            distance = _distance_meters(latitude, longitude, lat, lon)
+            detailed_locations.append((distance, location))
+
+    sorted_locations = sorted(detailed_locations, key=lambda item: item[0])
+    if not sorted_locations:
+        return []
+
+    unique_places = []
+    seen_names = set()
+    for _, location in sorted_locations:
+        key = (location.get("name"), location.get("state"))
+        if key in seen_names:
+            continue
+        seen_names.add(key)
+        unique_places.append(location)
+        if len(unique_places) >= limit * 3:
+            break
+
+    choices = []
+    seen_place_ids = set()
+
+    async with aiohttp.ClientSession(headers=headers) as session:
+        for location in unique_places:
+            name = location.get("name")
+            state = location.get("state")
+            if not name or not state:
+                continue
+
+            autocomplete_params = {
+                "name": f"{name} {state}",
+                "limit": "5",
+                "website-sort": "true",
+                "include-states": "true",
+                "include-districts": "true",
+            }
+
+            try:
+                async with session.get(
+                    PLACE_AUTOCOMPLETE_URL,
+                    params=autocomplete_params,
+                    headers={
+                        **headers,
+                        "Origin": "https://www.bom.gov.au",
+                        "Referer": "https://www.bom.gov.au/",
+                    },
+                ) as response:
+                    if response.status != 200:
+                        continue
+                    payload = await response.json()
+            except aiohttp.ClientError:
+                continue
+
+            candidates = payload.get("candidates", [])
+            place = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate.get("type") == "place"
+                    and candidate.get("name") == name
+                    and candidate.get("state") == state
+                ),
+                None,
+            )
+            if place is None:
+                place = next(
+                    (
+                        candidate
+                        for candidate in candidates
+                        if candidate.get("type") == "place"
+                    ),
+                    None,
+                )
+            if place is None:
+                continue
+
+            place_id = place.get("id")
+            if not place_id or place_id in seen_place_ids:
+                continue
+            seen_place_ids.add(place_id)
+
+            coordinate = place.get("coordinate", {})
+            place_latitude = coordinate.get("latitude")
+            place_longitude = coordinate.get("longitude")
+            if place_latitude is None or place_longitude is None:
+                continue
+
+            distance = _distance_meters(
+                latitude,
+                longitude,
+                place_latitude,
+                place_longitude,
+            )
+            forecast_geohash = geohash_encode(
+                place_latitude,
+                place_longitude,
+                precision=7,
+            )
+            observation_geohash = forecast_geohash
+            has_observations = False
+            station_name = None
+
+            for geohash in dict.fromkeys([forecast_geohash, forecast_geohash[:6]]):
+                try:
+                    async with session.get(
+                        f"{WEATHER_BOM_LOCATION_URL}{geohash}/observations"
+                    ) as response:
+                        if response.status != 200:
+                            continue
+                        payload = await response.json()
+                except aiohttp.ClientError:
+                    continue
+
+                data = payload.get("data")
+                if isinstance(data, dict) and data.get("temp") is not None:
+                    observation_geohash = geohash
+                    has_observations = True
+                    station_name = (data.get("station") or {}).get("name")
+                    break
+
+            forecast_label = (
+                f"{place.get('name')}, {place.get('state')} "
+                f"(Place {place_id}, {int(round(distance))}m)"
+            )
+            if has_observations and station_name:
+                observation_label = (
+                    f"{place.get('name')}, {place.get('state')} via {station_name}"
+                )
+            else:
+                observation_label = (
+                    f"{place.get('name')}, {place.get('state')} "
+                    f"via nearest fallback station"
+                )
+            choices.append(
+                {
+                    "forecast_geohash": forecast_geohash,
+                    "observation_geohash": observation_geohash,
+                    "forecast_label": forecast_label,
+                    "observation_label": observation_label,
+                    "label": forecast_label,
+                    "has_observations": has_observations,
+                    "place_id": place_id,
+                    "station_name": station_name,
+                }
+            )
+
+            if len(choices) >= limit:
+                break
+
+    return choices
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -33,6 +280,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    def __init__(self) -> None:
+        """Initialise the config flow."""
+        self.data = {}
+        self.collector = None
+        self._location_choices = []
 
     @staticmethod
     @callback
@@ -65,14 +318,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Check if location is valid
                 await self.collector.get_locations_data()
                 if self.collector.locations_data is None:
-                    _LOGGER.debug(f"Unsupported Lat/Lon")
+                    _LOGGER.debug("Unsupported Lat/Lon")
                     errors["base"] = "bad_location"
                 else:
-                    # Populate observations and daily forecasts data
-                    await self.collector.async_update()
+                    self._location_choices = await _get_top_location_choices(
+                        user_input[CONF_LATITUDE],
+                        user_input[CONF_LONGITUDE],
+                    )
 
-                    # Move onto the next step of the config flow
-                    return await self.async_step_weather_name()
+                    # Move onto the source selection step.
+                    return await self.async_step_location_source()
 
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -83,13 +338,104 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
+    async def async_step_location_source(self, user_input=None):
+        """Select the BoM location source from the closest options."""
+        if not self._location_choices:
+            fallback_geohash = _collector_forecast_geohash7(self.collector)
+            fallback_name = _collector_location_name(self.collector)
+            fallback_label = f"{fallback_name} [{fallback_geohash}]"
+            self._location_choices = [
+                {
+                    "forecast_geohash": fallback_geohash,
+                    "observation_geohash": fallback_geohash[:6],
+                    "forecast_label": fallback_label,
+                    "observation_label": f"{fallback_name} via nearest fallback station",
+                    "label": fallback_label,
+                    "has_observations": False,
+                }
+            ]
+
+        forecast_choice_map = {
+            choice["forecast_geohash"]: choice["forecast_label"]
+            for choice in self._location_choices
+        }
+        observation_choice_map = {
+            choice["observation_geohash"]: choice["observation_label"]
+            for choice in self._location_choices
+        }
+        default_forecast_geohash = self._location_choices[0]["forecast_geohash"]
+        default_observation_geohash = next(
+            (
+                choice["observation_geohash"]
+                for choice in self._location_choices
+                if choice["has_observations"]
+            ),
+            self._location_choices[0]["observation_geohash"],
+        )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_FORECAST_LOCATION_GEOHASH,
+                    default=self.data.get(
+                        CONF_FORECAST_LOCATION_GEOHASH,
+                        default_forecast_geohash,
+                    ),
+                ): vol.In(forecast_choice_map),
+                vol.Required(
+                    CONF_OBSERVATION_LOCATION_GEOHASH,
+                    default=self.data.get(
+                        CONF_OBSERVATION_LOCATION_GEOHASH,
+                        default_observation_geohash,
+                    ),
+                ): vol.In(observation_choice_map),
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+                forecast_geohash = self.data[CONF_FORECAST_LOCATION_GEOHASH]
+                selected_choice = next(
+                    (
+                        choice
+                        for choice in self._location_choices
+                        if choice["forecast_geohash"]
+                        == self.data[CONF_FORECAST_LOCATION_GEOHASH]
+                    ),
+                    None,
+                )
+                if selected_choice and selected_choice.get("place_id"):
+                    self.data[CONF_PLACE_ID] = selected_choice["place_id"]
+
+                self.collector = Collector(
+                    self.data[CONF_LATITUDE],
+                    self.data[CONF_LONGITUDE],
+                    forecast_geohash,
+                    self.data[CONF_OBSERVATION_LOCATION_GEOHASH],
+                    self.data.get(CONF_PLACE_ID),
+                )
+                await self.collector.get_locations_data()
+                await self.collector.async_update()
+
+                return await self.async_step_weather_name()
+
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="location_source", data_schema=data_schema, errors=errors
+        )
+
     async def async_step_weather_name(self, user_input=None):
         """Handle the locations step."""
         data_schema = vol.Schema(
             {
                 vol.Required(
                     CONF_WEATHER_NAME,
-                    default=self.collector.locations_data["data"]["name"],
+                    default=_collector_location_name(self.collector),
                 ): str,
             }
         )
@@ -138,7 +484,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_warnings_basename()
                 else:
                     return self.async_create_entry(
-                        title=self.collector.locations_data["data"]["name"],
+                        title=_collector_location_name(self.collector),
                         data=self.data,
                     )
 
@@ -163,7 +509,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(
                     CONF_OBSERVATIONS_BASENAME,
-                    default=self.collector.observations_data["data"]["station"]["name"],
+                    default=_collector_observation_station_name(self.collector),
                 ): str,
                 vol.Required(CONF_OBSERVATIONS_MONITORED): cv.multi_select(monitored),
             }
@@ -181,7 +527,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_warnings_basename()
                 else:
                     return self.async_create_entry(
-                        title=self.collector.locations_data["data"]["name"],
+                        title=_collector_location_name(self.collector),
                         data=self.data,
                     )
 
@@ -206,7 +552,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(
                     CONF_FORECASTS_BASENAME,
-                    default=self.collector.locations_data["data"]["name"],
+                    default=_collector_location_name(self.collector),
                 ): str,
                 vol.Required(CONF_FORECASTS_MONITORED): cv.multi_select(monitored),
                 vol.Required(CONF_FORECASTS_DAYS): vol.All(
@@ -223,7 +569,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if self.data[CONF_WARNINGS_CREATE]:
                     return await self.async_step_warnings_basename()
                 return self.async_create_entry(
-                    title=self.collector.locations_data["data"]["name"], data=self.data
+                    title=_collector_location_name(self.collector), data=self.data
                 )
 
             except CannotConnect:
@@ -243,7 +589,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(
                     CONF_WARNINGS_BASENAME,
-                    default=self.collector.locations_data["data"]["name"],
+                    default=_collector_location_name(self.collector),
                 ): str,
             }
         )
@@ -253,7 +599,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 self.data.update(user_input)
                 return self.async_create_entry(
-                    title=self.collector.locations_data["data"]["name"], data=self.data
+                    title=_collector_location_name(self.collector), data=self.data
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -274,6 +620,8 @@ class BomOptionsFlow(config_entries.OptionsFlow):
         """Initialise the options flow."""
         super().__init__()
         self.data = {}
+        self.collector = None
+        self._location_choices = []
 
     async def async_step_init(self, user_input=None):
         """Handle the initial step."""
@@ -315,14 +663,15 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                 # Check if location is valid
                 await self.collector.get_locations_data()
                 if self.collector.locations_data is None:
-                    _LOGGER.debug(f"Unsupported Lat/Lon")
+                    _LOGGER.debug("Unsupported Lat/Lon")
                     errors["base"] = "bad_location"
                 else:
-                    # Populate observations and daily forecasts data
-                    await self.collector.async_update()
+                    self._location_choices = await _get_top_location_choices(
+                        user_input[CONF_LATITUDE],
+                        user_input[CONF_LONGITUDE],
+                    )
 
-                    # Move onto the next step of the config flow
-                    return await self.async_step_weather_name()
+                    return await self.async_step_location_source()
 
             except Exception:
                 _LOGGER.exception("Unexpected exception")
@@ -331,6 +680,121 @@ class BomOptionsFlow(config_entries.OptionsFlow):
         # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
         return self.async_show_form(
             step_id="init", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_location_source(self, user_input=None):
+        """Select the BoM location source from the closest options."""
+        if not self._location_choices:
+            fallback_geohash = self.config_entry.options.get(
+                CONF_FORECAST_LOCATION_GEOHASH,
+                self.config_entry.data.get(
+                    CONF_FORECAST_LOCATION_GEOHASH,
+                    _collector_forecast_geohash7(self.collector),
+                ),
+            )
+            fallback_name = _collector_location_name(self.collector)
+            fallback_label = f"{fallback_name} [{fallback_geohash}]"
+            self._location_choices = [
+                {
+                    "forecast_geohash": fallback_geohash,
+                    "observation_geohash": fallback_geohash[:6],
+                    "forecast_label": fallback_label,
+                    "observation_label": f"{fallback_name} via nearest fallback station",
+                    "label": fallback_label,
+                    "has_observations": False,
+                }
+            ]
+
+        forecast_choice_map = {
+            choice["forecast_geohash"]: choice["forecast_label"]
+            for choice in self._location_choices
+        }
+        observation_choice_map = {
+            choice["observation_geohash"]: choice["observation_label"]
+            for choice in self._location_choices
+        }
+
+        default_forecast_geohash = self.config_entry.options.get(
+            CONF_FORECAST_LOCATION_GEOHASH,
+            self.config_entry.data.get(
+                CONF_FORECAST_LOCATION_GEOHASH,
+                self._location_choices[0]["forecast_geohash"],
+            ),
+        )
+        if default_forecast_geohash not in forecast_choice_map:
+            default_forecast_geohash = self._location_choices[0]["forecast_geohash"]
+
+        default_observation_geohash = self.config_entry.options.get(
+            CONF_OBSERVATION_LOCATION_GEOHASH,
+            self.config_entry.data.get(
+                CONF_OBSERVATION_LOCATION_GEOHASH,
+                default_forecast_geohash,
+            ),
+        )
+        if default_observation_geohash not in observation_choice_map:
+            default_observation_geohash = next(
+                (
+                    choice["observation_geohash"]
+                    for choice in self._location_choices
+                    if choice["has_observations"]
+                ),
+                self._location_choices[0]["observation_geohash"],
+            )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_FORECAST_LOCATION_GEOHASH,
+                    default=self.data.get(
+                        CONF_FORECAST_LOCATION_GEOHASH,
+                        default_forecast_geohash,
+                    ),
+                ): vol.In(forecast_choice_map),
+                vol.Required(
+                    CONF_OBSERVATION_LOCATION_GEOHASH,
+                    default=self.data.get(
+                        CONF_OBSERVATION_LOCATION_GEOHASH,
+                        default_observation_geohash,
+                    ),
+                ): vol.In(observation_choice_map),
+            }
+        )
+
+        errors = {}
+        if user_input is not None:
+            try:
+                self.data.update(user_input)
+                forecast_geohash = self.data[CONF_FORECAST_LOCATION_GEOHASH]
+                selected_choice = next(
+                    (
+                        choice
+                        for choice in self._location_choices
+                        if choice["forecast_geohash"]
+                        == self.data[CONF_FORECAST_LOCATION_GEOHASH]
+                    ),
+                    None,
+                )
+                if selected_choice and selected_choice.get("place_id"):
+                    self.data[CONF_PLACE_ID] = selected_choice["place_id"]
+
+                self.collector = Collector(
+                    self.data[CONF_LATITUDE],
+                    self.data[CONF_LONGITUDE],
+                    forecast_geohash,
+                    self.data[CONF_OBSERVATION_LOCATION_GEOHASH],
+                    self.data.get(CONF_PLACE_ID),
+                )
+                await self.collector.get_locations_data()
+                await self.collector.async_update()
+
+                return await self.async_step_weather_name()
+
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="location_source", data_schema=data_schema, errors=errors
         )
 
     async def async_step_weather_name(self, user_input=None):
@@ -343,7 +807,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                         CONF_WEATHER_NAME,
                         self.config_entry.data.get(
                             CONF_WEATHER_NAME,
-                            self.collector.locations_data["data"]["name"],
+                            _collector_location_name(self.collector),
                         ),
                     ),
                 ): str,
@@ -412,7 +876,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                     return await self.async_step_warnings_basename()
                 else:
                     return self.async_create_entry(
-                        title=self.collector.locations_data["data"]["name"],
+                        title=_collector_location_name(self.collector),
                         data=self.data,
                     )
 
@@ -441,7 +905,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                         CONF_OBSERVATIONS_BASENAME,
                         self.config_entry.data.get(
                             CONF_OBSERVATIONS_BASENAME,
-                            self.collector.observations_data["data"]["station"]["name"],
+                            _collector_observation_station_name(self.collector),
                         ),
                     ),
                 ): str,
@@ -467,7 +931,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                     return await self.async_step_warnings_basename()
                 else:
                     return self.async_create_entry(
-                        title=self.collector.locations_data["data"]["name"],
+                        title=_collector_location_name(self.collector),
                         data=self.data,
                     )
 
@@ -496,7 +960,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                         CONF_FORECASTS_BASENAME,
                         self.config_entry.data.get(
                             CONF_FORECASTS_BASENAME,
-                            self.collector.locations_data["data"]["name"],
+                            _collector_location_name(self.collector),
                         ),
                     ),
                 ): str,
@@ -525,7 +989,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                 if self.data[CONF_WARNINGS_CREATE]:
                     return await self.async_step_warnings_basename()
                 return self.async_create_entry(
-                    title=self.collector.locations_data["data"]["name"], data=self.data
+                    title=_collector_location_name(self.collector), data=self.data
                 )
 
             except CannotConnect:
@@ -549,7 +1013,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
                         CONF_WARNINGS_BASENAME,
                         self.config_entry.data.get(
                             CONF_WARNINGS_BASENAME,
-                            self.collector.locations_data["data"]["name"],
+                            _collector_location_name(self.collector),
                         ),
                     ),
                 ): str,
@@ -561,7 +1025,7 @@ class BomOptionsFlow(config_entries.OptionsFlow):
             try:
                 self.data.update(user_input)
                 return self.async_create_entry(
-                    title=self.collector.locations_data["data"]["name"], data=self.data
+                    title=_collector_location_name(self.collector), data=self.data
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"

--- a/custom_components/bureau_of_meteorology/const.py
+++ b/custom_components/bureau_of_meteorology/const.py
@@ -10,7 +10,6 @@ from homeassistant.components.sensor import (
 
 from homeassistant.const import (
     PERCENTAGE,
-    DEGREE,
     UnitOfTemperature,
     UnitOfLength,
     UnitOfSpeed,
@@ -23,6 +22,10 @@ COLLECTOR: Final = "collector"
 UPDATE_LISTENER: Final = "update_listener"
 
 CONF_WEATHER_NAME: Final = "weather_name"
+CONF_LOCATION_GEOHASH: Final = "location_geohash"
+CONF_FORECAST_LOCATION_GEOHASH: Final = "forecast_location_geohash"
+CONF_OBSERVATION_LOCATION_GEOHASH: Final = "observation_location_geohash"
+CONF_PLACE_ID: Final = "place_id"
 CONF_FORECASTS_BASENAME: Final = "forecasts_basename"
 CONF_FORECASTS_CREATE: Final = "forecasts_create"
 CONF_FORECASTS_DAYS: Final = "forecasts_days"

--- a/custom_components/bureau_of_meteorology/sensor.py
+++ b/custom_components/bureau_of_meteorology/sensor.py
@@ -1,13 +1,14 @@
 """Platform for sensor integration."""
+
 import logging
-from datetime import datetime, tzinfo, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 import iso8601
 import zoneinfo
-import math #Required for calculated observations (e.g dew point)
-from homeassistant.config_entries import ConfigEntry
+import math  # Required for calculated observations (e.g dew point)
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DATE,
@@ -15,11 +16,9 @@ from homeassistant.const import (
 )
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from zoneinfo import ZoneInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BomDataUpdateCoordinator
 from .const import (
@@ -156,8 +155,8 @@ async def async_setup_entry(
         if warnings_basename is not None:
             new_entities.append(
                 WarningsSensor(
-                    hass_data, 
-                    warnings_basename, 
+                    hass_data,
+                    warnings_basename,
                     "warnings",
                     [
                         description
@@ -174,7 +173,13 @@ async def async_setup_entry(
 class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
     """Base representation of a BOM Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name, description: SensorEntityDescription,) -> None:
+    def __init__(
+        self,
+        hass_data,
+        location_name,
+        sensor_name,
+        description: SensorEntityDescription,
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(hass_data[COORDINATOR])
         self.collector: Collector = hass_data[COLLECTOR]
@@ -211,11 +216,41 @@ class SensorBase(CoordinatorEntity[BomDataUpdateCoordinator], SensorEntity):
         """Refresh the data on the collector object."""
         await self.collector.async_update()
 
+    def _location_data(self) -> dict[str, Any]:
+        """Return location payload data with a non-optional type."""
+        return (self.collector.locations_data or {}).get("data", {})
+
+    def _observations_data(self) -> dict[str, Any]:
+        """Return observation payload data with a non-optional type."""
+        return (self.collector.observations_data or {}).get("data", {})
+
+    def _observations_metadata(self) -> dict[str, Any]:
+        """Return observation payload metadata with a non-optional type."""
+        return (self.collector.observations_data or {}).get("metadata", {})
+
+    def _daily_forecasts(self) -> list[dict[str, Any]]:
+        """Return daily forecast list with a non-optional type."""
+        return (self.collector.daily_forecasts_data or {}).get("data", [])
+
+    def _daily_forecasts_metadata(self) -> dict[str, Any]:
+        """Return daily forecast metadata with a non-optional type."""
+        return (self.collector.daily_forecasts_data or {}).get("metadata", {})
+
+    def _warnings_data(self) -> dict[str, Any]:
+        """Return warnings payload with a non-optional type."""
+        return self.collector.warnings_data or {"metadata": {}, "data": []}
+
 
 class ObservationSensor(SensorBase):
     """Representation of a BOM Observation Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name, description: SensorEntityDescription,):
+    def __init__(
+        self,
+        hass_data,
+        location_name,
+        sensor_name,
+        description: SensorEntityDescription,
+    ):
         """Initialize the sensor."""
         super().__init__(hass_data, location_name, sensor_name, description)
 
@@ -234,56 +269,66 @@ class ObservationSensor(SensorBase):
         """Return the state attributes of the sensor."""
         attr = {}
 
-        tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
-        for key in self.collector.observations_data["metadata"]:
+        location_data = self._location_data()
+        observations_data = self._observations_data()
+        observations_metadata = self._observations_metadata()
+        tzinfo = zoneinfo.ZoneInfo(location_data.get("timezone", "UTC"))
+        for key in observations_metadata:
             try:
-                attr[key] = iso8601.parse_date(self.collector.observations_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                attr[key] = (
+                    iso8601.parse_date(observations_metadata[key])
+                    .astimezone(tzinfo)
+                    .isoformat()
+                )
             except iso8601.ParseError:
-                attr[key] = self.collector.observations_data["metadata"][key]
+                attr[key] = observations_metadata[key]
 
-        attr.update(self.collector.observations_data["data"]["station"])
+        attr.update(observations_data.get("station", {}))
         attr[ATTR_ATTRIBUTION] = ATTRIBUTION
 
         # Only proceed for max_temp or min_temp
         if self.sensor_name not in ("max_temp", "min_temp"):
             return attr
-    
+
         # Get data safely
-        data = self.collector.observations_data.get("data")
+        data = observations_data
         if not data:
             return attr
-    
+
         # Get sensor data safely
         sensor_data = data.get(self.sensor_name)
         if not sensor_data:
             return attr
-    
+
         # Get time safely
         time_str = sensor_data.get("time")
         if not time_str:
             return attr
 
         # We have all required data, now add the time_observed attribute
-        attr["time_observed"] = iso8601.parse_date(time_str).astimezone(tzinfo).isoformat()
+        attr["time_observed"] = (
+            iso8601.parse_date(time_str).astimezone(tzinfo).isoformat()
+        )
         return attr
 
     @property
     def state(self):
         """Return the state of the sensor."""
+        observations_data = self._observations_data()
         if self.sensor_name == "dew_point":
-            temperature = self.collector.observations_data["data"]["temp"]
-            humidity = self.collector.observations_data["data"]["humidity"]
+            temperature = observations_data.get("temp")
+            humidity = observations_data.get("humidity")
             if temperature is not None and humidity is not None:
                 return calculate_dew_point(temperature, humidity)
             else:
                 return None
         else:
-            if self.sensor_name in self.collector.observations_data["data"]:
-                if self.collector.observations_data["data"][self.sensor_name] is not None:
+            if self.sensor_name in observations_data:
+                if observations_data[self.sensor_name] is not None:
                     if self.sensor_name == "max_temp" or self.sensor_name == "min_temp":
-                        return self.collector.observations_data["data"][self.sensor_name]["value"]
+                        return observations_data[self.sensor_name]["value"]
                     else:
-                        return self.collector.observations_data["data"][self.sensor_name]
+                        return observations_data[self.sensor_name]
             else:
                 return "unavailable"
 
@@ -296,7 +341,14 @@ class ObservationSensor(SensorBase):
 class ForecastSensor(SensorBase):
     """Representation of a BOM Forecast Sensor."""
 
-    def __init__(self, hass_data, location_name, day, sensor_name, description: SensorEntityDescription,):
+    def __init__(
+        self,
+        hass_data,
+        location_name,
+        day,
+        sensor_name,
+        description: SensorEntityDescription,
+    ):
         """Initialize the sensor."""
         self.day = day
         super().__init__(hass_data, location_name, sensor_name, description)
@@ -315,65 +367,103 @@ class ForecastSensor(SensorBase):
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         attr = {}
+        forecasts_data = self._daily_forecasts()
+        forecasts_metadata = self._daily_forecasts_metadata()
 
         # If there is no data for this day, do not add attributes for this day.
-        if self.day < len(self.collector.daily_forecasts_data["data"]):
-            tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
-            for key in self.collector.daily_forecasts_data["metadata"]:
+        if self.day < len(forecasts_data):
+            tzinfo = zoneinfo.ZoneInfo(self._location_data().get("timezone", "UTC"))
+            for key in forecasts_metadata:
                 try:
-                    attr[key] = iso8601.parse_date(self.collector.daily_forecasts_data["metadata"][key]).astimezone(tzinfo).isoformat()
+                    attr[key] = (
+                        iso8601.parse_date(forecasts_metadata[key])
+                        .astimezone(tzinfo)
+                        .isoformat()
+                    )
                 except iso8601.ParseError:
-                    attr[key] = self.collector.daily_forecasts_data["metadata"][key]
+                    attr[key] = forecasts_metadata[key]
             attr[ATTR_ATTRIBUTION] = ATTRIBUTION
-            attr[ATTR_DATE] = iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day]["date"]).astimezone(tzinfo).isoformat()
-            if (self.sensor_name == "fire_danger") and (self.current_state != None):
-                if self.collector.daily_forecasts_data["data"][self.day]["fire_danger_category"]["default_colour"]:
-                    attr["color_fill"] = self.collector.daily_forecasts_data["data"][self.day]["fire_danger_category"]["default_colour"]
-                    attr["color_text"] =  "#ffffff" if (self.collector.daily_forecasts_data["data"][self.day]["fire_danger_category"]["text"] == "Catastrophic") else "#000000"
+            attr[ATTR_DATE] = (
+                iso8601.parse_date(forecasts_data[self.day]["date"])
+                .astimezone(tzinfo)
+                .isoformat()
+            )
+            if (self.sensor_name == "fire_danger") and (self.current_state is not None):
+                if forecasts_data[self.day]["fire_danger_category"]["default_colour"]:
+                    attr["color_fill"] = forecasts_data[self.day][
+                        "fire_danger_category"
+                    ]["default_colour"]
+                    attr["color_text"] = (
+                        "#ffffff"
+                        if forecasts_data[self.day]["fire_danger_category"]["text"]
+                        == "Catastrophic"
+                        else "#000000"
+                    )
             if self.sensor_name.startswith("extended"):
-                attr[ATTR_STATE] = self.collector.daily_forecasts_data["data"][self.day]["extended_text"]
+                attr[ATTR_STATE] = forecasts_data[self.day]["extended_text"]
         return attr
 
     @property
     def state(self):
         """Return the state of the sensor."""
+        forecasts_data = self._daily_forecasts()
         # If there is no data for this day, return state as 'None'.
-        if self.day < len(self.collector.daily_forecasts_data["data"]):
+        if self.day < len(forecasts_data):
             if self.device_class == SensorDeviceClass.TIMESTAMP:
-                tzinfo = zoneinfo.ZoneInfo(
-                    self.collector.locations_data["data"]["timezone"]
-                )
+                tzinfo = zoneinfo.ZoneInfo(self._location_data().get("timezone", "UTC"))
                 try:
-                    return iso8601.parse_date(self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]).astimezone(tzinfo).isoformat()
+                    return (
+                        iso8601.parse_date(forecasts_data[self.day][self.sensor_name])
+                        .astimezone(tzinfo)
+                        .isoformat()
+                    )
                 except iso8601.ParseError:
-                    return self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
+                    return forecasts_data[self.day][self.sensor_name]
             if self.sensor_name == "uv_forecast":
-                if (self.collector.daily_forecasts_data["data"][self.day]["uv_category"] is None):
+                if forecasts_data[self.day]["uv_category"] is None:
                     return None
-                if (self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"] is None):
+                if forecasts_data[self.day]["uv_start_time"] is None:
                     return (
                         f"Sun protection not required, UV Index predicted to reach "
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
-                        f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
+                        f"{forecasts_data[self.day]['uv_max_index']} "
+                        f"[{forecasts_data[self.day]['uv_category'].replace('veryhigh', 'very high').title()}]"
                     )
                 else:
                     utc = timezone.utc
-                    local = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
-                    start_time = datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_start_time"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc).astimezone(local)
-                    end_time = datetime.strptime(self.collector.daily_forecasts_data["data"][self.day]["uv_end_time"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc).astimezone(local)
-                    return (
-                        f'Sun protection recommended from {start_time.strftime("%-I:%M%p").lower()} to '
-                        f'{end_time.strftime("%-I:%M%p").lower()}, UV Index predicted to reach '
-                        f'{self.collector.daily_forecasts_data["data"][self.day]["uv_max_index"]} '
-                        f'[{self.collector.daily_forecasts_data["data"][self.day]["uv_category"].replace("veryhigh", "very high").title()}]'
+                    local = zoneinfo.ZoneInfo(
+                        self._location_data().get("timezone", "UTC")
                     )
-            new_state = self.collector.daily_forecasts_data["data"][self.day][self.sensor_name]
-            if type(new_state) == str and len(new_state) > 251:
+                    start_time = (
+                        datetime.strptime(
+                            forecasts_data[self.day]["uv_start_time"],
+                            "%Y-%m-%dT%H:%M:%SZ",
+                        )
+                        .replace(tzinfo=utc)
+                        .astimezone(local)
+                    )
+                    end_time = (
+                        datetime.strptime(
+                            forecasts_data[self.day]["uv_end_time"],
+                            "%Y-%m-%dT%H:%M:%SZ",
+                        )
+                        .replace(tzinfo=utc)
+                        .astimezone(local)
+                    )
+                    return (
+                        f"Sun protection recommended from {start_time.strftime('%-I:%M%p').lower()} to "
+                        f"{end_time.strftime('%-I:%M%p').lower()}, UV Index predicted to reach "
+                        f"{forecasts_data[self.day]['uv_max_index']} "
+                        f"[{forecasts_data[self.day]['uv_category'].replace('veryhigh', 'very high').title()}]"
+                    )
+            new_state = forecasts_data[self.day][self.sensor_name]
+            if isinstance(new_state, str) and len(new_state) > 251:
                 self.current_state = new_state[:251] + "..."
             else:
                 self.current_state = new_state
-            if (self.sensor_name == "uv_category") and (self.current_state != None):
-                self.current_state = self.current_state.replace("veryhigh", "very high").title()
+            if (self.sensor_name == "uv_category") and (self.current_state is not None):
+                self.current_state = self.current_state.replace(
+                    "veryhigh", "very high"
+                ).title()
             return self.current_state
         else:
             return None
@@ -387,7 +477,13 @@ class ForecastSensor(SensorBase):
 class WarningsSensor(SensorBase):
     """Representation of a BOM Warnings Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name, description: SensorEntityDescription,):
+    def __init__(
+        self,
+        hass_data,
+        location_name,
+        sensor_name,
+        description: SensorEntityDescription,
+    ):
         """Initialize the sensor."""
         super().__init__(hass_data, location_name, sensor_name, description)
 
@@ -404,16 +500,17 @@ class WarningsSensor(SensorBase):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        attr = self.collector.warnings_data["metadata"]
+        warnings_data = self._warnings_data()
+        attr = warnings_data["metadata"]
         attr[ATTR_ATTRIBUTION] = ATTRIBUTION
-        attr["warnings"] = self.collector.warnings_data["data"]
+        attr["warnings"] = warnings_data["data"]
         return attr
 
     @property
     def state(self):
         """Return the state of the sensor."""
         # If there is no data for this day, return state as 'None'.
-        return len(self.collector.warnings_data["data"])
+        return len(self._warnings_data()["data"])
 
     @property
     def name(self):
@@ -424,7 +521,13 @@ class WarningsSensor(SensorBase):
 class NowLaterSensor(SensorBase):
     """Representation of a BOM Forecast Sensor."""
 
-    def __init__(self, hass_data, location_name, sensor_name, description: SensorEntityDescription,):
+    def __init__(
+        self,
+        hass_data,
+        location_name,
+        sensor_name,
+        description: SensorEntityDescription,
+    ):
         """Initialize the sensor."""
         super().__init__(hass_data, location_name, sensor_name, description)
 
@@ -441,16 +544,17 @@ class NowLaterSensor(SensorBase):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
-        attr = self.collector.daily_forecasts_data["metadata"]
+        attr = self._daily_forecasts_metadata()
         attr[ATTR_ATTRIBUTION] = ATTRIBUTION
         return attr
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        self.current_state = self.collector.daily_forecasts_data["data"][0][
-            self.sensor_name
-        ]
+        forecasts_data = self._daily_forecasts()
+        if not forecasts_data:
+            return None
+        self.current_state = forecasts_data[0][self.sensor_name]
         return self.current_state
 
     @property
@@ -458,9 +562,12 @@ class NowLaterSensor(SensorBase):
         """Return the name of the sensor."""
         return f"{self.location_name} {self.sensor_name.replace('_', ' ').title()}"
 
+
 def calculate_dew_point(temperature, humidity):
     """Calculate dew point using temperature and humidity observations"""
     a, b = 17.27, 237.7  # Tetens equation constants
-    saturation_factor = ((a * temperature) / (b + temperature)) + math.log(humidity / 100.0)
+    saturation_factor = ((a * temperature) / (b + temperature)) + math.log(
+        humidity / 100.0
+    )
     dew_point = (b * saturation_factor) / (a - saturation_factor)
     return round(dew_point, 1)

--- a/custom_components/bureau_of_meteorology/strings.json
+++ b/custom_components/bureau_of_meteorology/strings.json
@@ -9,6 +9,14 @@
           "longitude": "[%key:common::config_flow::data::longitude%]"
         }
       },
+      "location_source": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "forecast_location_geohash": "[%key:common::config_flow::data::forecast_location_geohash%]",
+          "observation_location_geohash": "[%key:common::config_flow::data::observation_location_geohash%]"
+        }
+      },
       "weather_name": {
         "title": "[%key:common::config_flow::title%]",
         "description": "[%key:common::config_flow::description%]",
@@ -59,6 +67,14 @@
         "data": {
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]"
+        }
+      },
+      "location_source": {
+        "title": "[%key:common::config_flow::title%]",
+        "description": "[%key:common::config_flow::description%]",
+        "data": {
+          "forecast_location_geohash": "[%key:common::config_flow::data::forecast_location_geohash%]",
+          "observation_location_geohash": "[%key:common::config_flow::data::observation_location_geohash%]"
         }
       },
       "weather_name": {

--- a/custom_components/bureau_of_meteorology/translations/en.json
+++ b/custom_components/bureau_of_meteorology/translations/en.json
@@ -17,6 +17,14 @@
                     "longitude": "Longitude"
                 }
             },
+            "location_source": {
+                "title": "Choose BoM Location Source",
+                "description": "Select one of the 3 closest canonical BoM places for forecasts and the observation path Home Assistant should follow. Forecasts use the BoM place model; observations may use the nearest matching station.",
+                "data": {
+                    "forecast_location_geohash": "BoM forecast place",
+                    "observation_location_geohash": "BoM observation path"
+                }
+            },
             "weather_name": {
                 "title": "Choose Weather Entity Name",
                 "description": "The weather entity in homeassistant holds all the basic weather observation and forecast information needed for most weather display cards. You can choose the name of your BoM weather entity (eg. Warrnambool for \"weather.warrnambool\" or home for \"weather.home\").",
@@ -75,6 +83,14 @@
                 "data": {
                     "latitude": "Latitude",
                     "longitude": "Longitude"
+                }
+            },
+            "location_source": {
+                "title": "Choose BoM Location Source",
+                "description": "Select one of the 3 closest canonical BoM places for forecasts and the observation path Home Assistant should follow. Forecasts use the BoM place model; observations may use the nearest matching station.",
+                "data": {
+                    "forecast_location_geohash": "BoM forecast place",
+                    "observation_location_geohash": "BoM observation path"
                 }
             },
             "weather_name": {

--- a/custom_components/bureau_of_meteorology/weather.py
+++ b/custom_components/bureau_of_meteorology/weather.py
@@ -1,21 +1,19 @@
 """Platform for sensor integration."""
+
 from __future__ import annotations
 
 import logging
-from datetime import datetime, tzinfo
+from typing import Any
 
 import iso8601
 import zoneinfo
-from homeassistant.components.weather import Forecast, WeatherEntity, WeatherEntityFeature
+from homeassistant.components.weather import Forecast, WeatherEntity
+from homeassistant.components.weather.const import WeatherEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfSpeed, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from zoneinfo import ZoneInfo
 
 from . import BomDataUpdateCoordinator
 from .const import (
@@ -75,42 +73,68 @@ class WeatherBase(WeatherEntity):
         self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
         self._update_callback()
 
+    def _location_data(self) -> dict[str, Any]:
+        """Return location payload data with a non-optional type."""
+        return (self.collector.locations_data or {}).get("data", {})
+
+    def _observations_data(self) -> dict[str, Any]:
+        """Return observation payload data with a non-optional type."""
+        return (self.collector.observations_data or {}).get("data", {})
+
+    def _daily_forecasts(self) -> list[dict[str, Any]]:
+        """Return daily forecast list with a non-optional type."""
+        return (self.collector.daily_forecasts_data or {}).get("data", [])
+
+    def _hourly_forecasts(self) -> list[dict[str, Any]]:
+        """Return hourly forecast list with a non-optional type."""
+        return (self.collector.hourly_forecasts_data or {}).get("data", [])
+
     async def async_forecast_daily(self) -> list[Forecast]:
-        tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
+        location_data = self._location_data()
+        tzinfo = zoneinfo.ZoneInfo(location_data.get("timezone", "UTC"))
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["date"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
+                datetime=iso8601.parse_date(data["date"])
+                .astimezone(tzinfo)
+                .replace(tzinfo=None)
+                .isoformat(),
                 native_temperature=data["temp_max"],
                 condition=MAP_CONDITION[data["icon_descriptor"]],
-                templow=data["temp_min"],
+                native_templow=data["temp_min"],
                 native_precipitation=data["rain_amount_max"],
                 precipitation_probability=data["rain_chance"],
             )
-            for data in self.collector.daily_forecasts_data["data"]
+            for data in self._daily_forecasts()
         ]
 
     async def async_forecast_hourly(self) -> list[Forecast]:
-        tzinfo = zoneinfo.ZoneInfo(self.collector.locations_data["data"]["timezone"])
+        location_data = self._location_data()
+        tzinfo = zoneinfo.ZoneInfo(location_data.get("timezone", "UTC"))
         return [
             Forecast(
-                datetime=iso8601.parse_date(data["time"]).astimezone(tzinfo).replace(tzinfo=None).isoformat(),
+                datetime=iso8601.parse_date(data["time"])
+                .astimezone(tzinfo)
+                .replace(tzinfo=None)
+                .isoformat(),
                 native_temperature=data["temp"],
                 condition=MAP_CONDITION[data["icon_descriptor"]],
                 native_precipitation=data["rain_amount_max"],
                 precipitation_probability=data["rain_chance"],
                 wind_bearing=data["wind_direction"],
                 native_wind_speed=data["wind_speed_kilometre"],
-                wind_gust_speed=data["wind_gust_speed_kilometre"],
+                native_wind_gust_speed=data["wind_gust_speed_kilometre"],
                 humidity=data["relative_humidity"],
                 uv_index=data["uv"],
             )
-            for data in self.collector.hourly_forecasts_data["data"]
+            for data in self._hourly_forecasts()
         ]
 
     @property
     def supported_features(self) -> WeatherEntityFeature:
-      """Determine supported features based on available data sets reported by WeatherKit."""
-      return WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
+        """Determine supported features based on available data sets reported by WeatherKit."""
+        return (
+            WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
+        )
 
     @callback
     def _update_callback(self) -> None:
@@ -125,12 +149,13 @@ class WeatherBase(WeatherEntity):
     @property
     def native_temperature(self):
         """Return the platform temperature."""
-        return self.collector.observations_data["data"]["temp"]
+        return self._observations_data().get("temp")
 
     @property
     def icon(self):
         """Return the icon."""
-        return self.collector.daily_forecasts_data["data"][0]["mdi_icon"]
+        forecasts = self._daily_forecasts()
+        return forecasts[0].get("mdi_icon") if forecasts else None
 
     @property
     def native_temperature_unit(self):
@@ -140,12 +165,12 @@ class WeatherBase(WeatherEntity):
     @property
     def humidity(self):
         """Return the humidity."""
-        return self.collector.observations_data["data"]["humidity"]
+        return self._observations_data().get("humidity")
 
     @property
     def native_wind_speed(self):
         """Return the wind speed."""
-        return self.collector.observations_data["data"]["wind_speed_kilometre"]
+        return self._observations_data().get("wind_speed_kilometre")
 
     @property
     def native_wind_speed_unit(self):
@@ -155,7 +180,7 @@ class WeatherBase(WeatherEntity):
     @property
     def wind_bearing(self):
         """Return the wind bearing."""
-        return self.collector.observations_data["data"]["wind_direction"]
+        return self._observations_data().get("wind_direction")
 
     @property
     def attribution(self):
@@ -163,14 +188,41 @@ class WeatherBase(WeatherEntity):
         return ATTRIBUTION
 
     @property
+    def extra_state_attributes(self):
+        """Return source details for diagnostics."""
+        attrs = {}
+        location_data = self._location_data()
+        attrs["source_location_name"] = location_data.get("name")
+        attrs["source_location_id"] = location_data.get("id")
+        attrs["source_forecasts_geohash"] = self.collector.selected_forecasts_geohash
+        attrs["source_daily_forecasts_geohash"] = (
+            self.collector.selected_daily_forecasts_geohash
+        )
+        attrs["source_hourly_forecasts_geohash"] = (
+            self.collector.selected_hourly_forecasts_geohash
+        )
+        attrs["source_observations_geohash"] = (
+            self.collector.selected_observations_geohash
+        )
+
+        station = self._observations_data().get("station")
+        if station:
+            attrs["source_station_name"] = station.get("name")
+            attrs["source_station_bom_id"] = station.get("bom_id")
+            attrs["source_station_distance_m"] = station.get("distance")
+
+        return attrs
+
+    @property
     def condition(self):
         """Return the current condition."""
-        return MAP_CONDITION[
-            self.collector.daily_forecasts_data["data"][0]["icon_descriptor"]
-        ]
+        forecasts = self._daily_forecasts()
+        if not forecasts:
+            return None
+        return MAP_CONDITION[forecasts[0]["icon_descriptor"]]
 
     async def async_update(self):
-        await self.coordinator.async_update()
+        await self.coordinator.async_request_refresh()
 
 
 class WeatherDaily(WeatherBase):
@@ -186,7 +238,7 @@ class WeatherDaily(WeatherBase):
 
     @property
     def supported_features(self):
-      return WeatherEntityFeature.FORECAST_DAILY
+        return WeatherEntityFeature.FORECAST_DAILY
 
     @property
     def name(self):
@@ -212,7 +264,7 @@ class WeatherHourly(WeatherBase):
 
     @property
     def supported_features(self):
-      return WeatherEntityFeature.FORECAST_HOURLY
+        return WeatherEntityFeature.FORECAST_HOURLY
 
     @property
     def name(self):


### PR DESCRIPTION
## Summary
This PR moves the integration to a place-first BoM API model and improves how forecast and observation sources are selected.
It also adds a setup/options step that lets users choose nearby canonical BoM place sources.

## What changed
1. Place/grid/station source model
- Added support for canonical BoM place selection and storage of source identifiers.
- Forecast data now prefers BoM place/grid endpoints.
- Observation data can follow a separate observation path, including nearest-station fallback.
- Warnings now use coordinate-based endpoints from the place model when available.

2. Setup and options flow
- Added a new location source selection step in both initial setup and options.
- Users can choose a forecast location source and an observation location source.
- Selected place id is stored when available.
- Added fallback handling when canonical choices are unavailable.

3. Runtime and coordinator updates
- Entry setup now resolves source settings from options/data consistently.
- Collector initialization now receives forecast source, observation source, and place id.
- Coordinator/device cleanup updated to track entry id explicitly.
- Added safe defaults for monitored options during unload.

4. Weather/sensor behavior updates
- Weather entity now handles missing payload data more defensively.
- Forecast mapping updated to current Home Assistant forecast attributes.
- Added weather diagnostic attributes for selected source geohashes and station metadata.
- Weather refresh path now requests coordinator refresh.

5. Docs and localization
- README updated with the new API source model and fallback behavior.
- API documentation rewritten to describe current place/grid/station usage.
- Added config flow strings/translations for the new location source step.

## Compatibility and migration notes
- Legacy geohash API remains as a compatibility fallback.
- Existing entries continue to work.
- Options can now override forecast and observation source selection independently.

## Validation performed
- Manual setup flow verified: location to source selection to entity creation.
- Manual options flow verified: source re-selection and persistence.
- Confirmed forecast, observations, and warnings resolve through the new source model with fallback behavior.

## Why this matters
This aligns integration data sourcing with current BoM website/app behavior and gives users clearer control over which nearby source path is used for forecasts and observations.

## Example of location UI

<img width="563" height="648" alt="image" src="https://github.com/user-attachments/assets/03e9a298-6b0a-4e4c-88fe-d55d01466544" />

Fixes #290 